### PR TITLE
UI redesign + alarm system for the 40L run-control GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ build/
 
 #Mac OS Files
 .DS_Store
+
+# Event log pane's on-disk mirror (one timestamped file per run)
+event_log_*.log

--- a/README.md
+++ b/README.md
@@ -1,9 +1,119 @@
 # 40L-Run-Control
 
-Repository of code for a run control program for the 40L TPC. Intended to measure/plot vessel pressure and VMM temperature in real time, and to control the experiment remotely.
+Repository of code for a run control program for the 40L TPC. Intended to measure/plot vessel pressure and VMM temperature in real time, control the experiment remotely, and alarm on out-of-range readings.
 
-## launch_GUI.py
+## Running it
 
-Run this script to launch the run control GUI. The widgets (plots, buttons, etc.) to display can be specified in the file using functions in the LivePlotter and LiveTab classes (from core_tools/gui/live_plotter_GUI_class.py). Some notes about how to use launch_GUI.py are left as comments inside the file.
+Install Python and `pip install -r requirements.txt` (add `-r requirements-dev.txt` instead if you also want to run the test suite). Then:
 
-Before running, make sure to install Python and pip install the libraries in requirements.txt
+```
+python launch_GUI.py
+```
+
+## Architecture
+
+- `core_tools/gui/live_plotter_GUI_class.py` is the GUI backend (`LivePlotter`, `LiveTab`, `OverviewTab`, `VMMTab`, `ControlDock`, `StatusStrip`, `AlarmBanner`, `EventLog`).
+- `launch_GUI.py` is the *design* — the only file a scientist needs to touch to add a channel, plot, alarm limit, logger, or status-strip tile. It's declarative: register channels, then plots/tabs that reference them by id.
+- `core_tools/alarms.py` is the alarm state machine. It's pure Python (no Qt) so it can be unit-tested and, later, run headless.
+- Data logging runs in **separate subprocesses** that write plain CSV/DAT files; the GUI only ever reads those files. This is deliberate — logs survive a GUI crash and stay usable for offline analysis. Never move logging into the GUI process.
+- A single scan timer on `LivePlotter` (default 1s) reads every registered channel's file on a background thread, evaluates alarms, and pushes fresh data into every unpaused plot. There's no per-plot timer — pausing a plot only stops its own curve redraw; the channel keeps being evaluated for alarms regardless.
+
+## launch_GUI.py API
+
+### Channels
+
+A channel is a data source, declared once, independent of whether any plot displays it (a channel with no plot is still evaluated for alarms and can still appear in the status strip):
+
+```python
+plotter.add_channel(
+    id='ov_pressure_g1',             # stable key, used everywhere else below
+    label='OV g1',                   # short label, for tiles/strip/readouts
+    long_label='Outer Vessel Gauge 1 Pressure',
+    filepath=outer_vessel_pressure_log_filepath,
+    datatype='outer_vessel_gauge_1_pressure',   # dispatch key -- see get_data_for_GUI.py
+    units='Torr',
+    log_interval_s=2,                # REQUIRED -- drives staleness and the time-window row count
+    alarm=AlarmSpec(high=760.0, clear_high=750.0),   # optional
+    vmm_num=None,                     # 0-15 for VMM temperature channels only
+    overview_group=None,              # heading on the Overview tab, e.g. 'Outer Vessel'
+)
+```
+
+Supported `datatype` values, and the file format each expects, are documented at the top of `core_tools/gui/get_data_for_GUI.py`.
+
+### Alarms
+
+`AlarmSpec` (`core_tools/alarms.py`) fields: `high`, `low`, `clear_high`, `clear_low`, `abs_high`, `clear_abs_high` (all optional — set the ones relevant to that channel), `consecutive_samples=3` (debounce), `stale_multiplier=5` (staleness = `stale_multiplier * log_interval_s` seconds without a fresh sample). All thresholds are declared here, in `launch_GUI.py`, only — there's no runtime threshold editing and no separate config file.
+
+Alarm evaluation always uses each channel's **raw** value, never an offset-adjusted one, so tuning a plot's display offset can't silently move a trip point.
+
+States are `OK`, `ALARM`, `STALE`, `NO_DATA` — there's no warn tier. Alarms **latch**: when a value returns in range the banner doesn't disappear, it shows "cleared, peak X at HH:MM:SS" until acknowledged, so a transient during an unattended stretch is never silently lost.
+
+### Plots
+
+```python
+gas_tab.add_plot(
+    plot_id='ov_pressure',           # stable key, never shown to the user
+    title='Outer Vessel Pressure',   # display string, freely renameable
+    channels=['ov_pressure_g1', 'ov_pressure_g2'],
+    x_axis=('Time since present', 's'),
+    y_axis=('Pressure', 'Torr'),
+    offsets=[0, 0],                  # one per channel, display-only
+    group='Outer Vessel',            # which QGroupBox on this tab it's wrapped in
+)
+```
+
+Multi-channel plots get a real legend (colors are never encoded in the title). Each channel with an `alarm` gets a dashed threshold line (offset-corrected so it still lines up with the trace) and the plot's border/title turn red while any of its channels is in `ALARM`. How much history is shown is governed by the global time-window selector in the control dock, not a per-plot setting.
+
+### Tabs
+
+- `plotter.build_overview_tab()` — call this **before** any other tab so it lands first. Dashboard of tiles (value + 5-minute sparkline) grouped by each channel's `overview_group`; no live plots. Build it after every `add_channel()` call it should reflect.
+- `plotter.create_tab(tab_name, plots_per_row)` — a regular tab; call `.add_plot(...)` on the result.
+- `plotter.build_vmm_tab(tab_name, channel_ids, threshold=None)` — the VMM Temperatures tab: a 4×4 tile grid (checkbox, current value, alarm color) beside one overlay plot of every checked channel's curve. `threshold=None` derives the single threshold line from the first channel's `AlarmSpec.high`.
+
+### Logger controls
+
+```python
+gas_tab.add_logger_control(
+    id='log_ov_pressure',
+    label='OV Pressure',
+    script='log_pressure.py',
+    log_filepath=outer_vessel_pressure_log_filepath,
+    port='COM3',                     # default; overridable from a live port dropdown at runtime
+    interval_options=[('2s', 2), ('10s', 10), ('1m', 60), ('10m', 600), ('1hr', 3600)],
+    default_interval=2,
+)
+```
+
+Builds a group box (LED, port dropdown from `serial.tools.list_ports`, interval dropdown, Start/Stop) in the shared control dock. The subprocess is launched as `[sys.executable, script, log_filepath, port, str(interval)]` — a real argv list, never a shell string, so filenames and ports can contain spaces. An unexpected exit turns the LED red and shows the last stderr line; it never silently flips back to "running". Changing the interval while a logger is running is stashed and applied on the next start.
+
+### Status strip
+
+Always visible above the tabs:
+
+```python
+plotter.set_status_strip([
+    'ov_pressure_g1', 'ov_pressure_g2', 'gauge_pressure',
+    'filter_line_flow', 'filter_line_pressure', 'filter_line_h2o',
+    AggregateTile(label='VMM max', channels=[f'vmm_temp_{i}' for i in range(16)],
+                  reduce='max', jump_to_tab='VMM Temperatures'),
+])
+```
+
+A plain channel id becomes a tile showing its label/value/units. `AggregateTile` reduces (`'max'` or `'min'`) over several channels and shows the worst one's value plus its index. Clicking any tile jumps to that channel's detail plot (or, for an `AggregateTile`, to `jump_to_tab`).
+
+### Time window and other global controls
+
+The control dock (right-hand pane) also carries: the global time-window selector (`1m`/`5m`/`15m`/`1h`/`6h`/`24h`, persisted via `QSettings`; each plot fetches `ceil(window_s / channel.log_interval_s)` rows, decimated to ~20000 points via min/max-per-bucket bucketing if that's exceeded so a spike is never hidden), Pause All / Resume All (curve redraws only — never affects alarm evaluation), and Acknowledge All.
+
+### Event log
+
+Bottom pane, collapsible, filterable. Every alarm transition, logger start/stop/crash, captured subprocess stderr, and runtime threshold/interval change is logged there and mirrored to a timestamped `event_log_*.log` file in the working directory, so it survives a GUI crash the same way the data logs do.
+
+## Testing
+
+```
+pytest tests/ -v
+```
+
+`core_tools/alarms.py` and `core_tools/gui/decimate.py` are pure Python with no Qt dependency, so their test suites run headless with no display. GUI code can also be smoke-tested headlessly with `QT_QPA_PLATFORM=offscreen python launch_GUI.py`.

--- a/core_tools/alarms.py
+++ b/core_tools/alarms.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+
+'''Pure-Python alarm definitions. No Qt imports here (and none should be added) so
+this module can be evaluated headlessly and unit-tested without a display.'''
+
+
+@dataclass
+class AlarmSpec:
+    high: float | None = None
+    low: float | None = None
+    clear_high: float | None = None
+    clear_low: float | None = None
+    abs_high: float | None = None
+    clear_abs_high: float | None = None
+    consecutive_samples: int = 3
+    stale_multiplier: float = 5

--- a/core_tools/alarms.py
+++ b/core_tools/alarms.py
@@ -1,7 +1,31 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import Enum
+import math
 
-'''Pure-Python alarm definitions. No Qt imports here (and none should be added) so
-this module can be evaluated headlessly and unit-tested without a display.'''
+'''Pure-Python alarm state machine. No Qt imports here (and none should be added) so
+this module can be evaluated headlessly and unit-tested without a display -- the GUI
+subscribes to the AlarmTransition objects this produces, it never re-implements the
+logic itself.
+
+There is no warn tier -- AlarmState below is the complete, final set of raw
+conditions. "CLEARED" is not a raw condition; it is a *presentation* of state==OK (or
+NO_DATA) while an earlier ALARM/STALE episode is still latched and unacknowledged --
+see DisplayStatus and display_status().'''
+
+
+class AlarmState(Enum):
+    OK = 'OK'
+    ALARM = 'ALARM'
+    STALE = 'STALE'
+    NO_DATA = 'NO_DATA'
+
+
+class DisplayStatus(Enum):
+    OK = 'OK'
+    ALARM = 'ALARM'
+    STALE = 'STALE'
+    CLEARED = 'CLEARED'
+    NO_DATA = 'NO_DATA'
 
 
 @dataclass
@@ -14,3 +38,239 @@ class AlarmSpec:
     clear_abs_high: float | None = None
     consecutive_samples: int = 3
     stale_multiplier: float = 5
+
+
+@dataclass
+class AlarmTransition:
+    channel_id: str
+    from_state: AlarmState
+    to_state: AlarmState
+    timestamp: float
+    value: float | None
+    message: str
+
+
+@dataclass
+class ChannelAlarmState:
+    channel_id: str
+    state: AlarmState = AlarmState.OK
+    consecutive_breach: int = 0
+    latched: bool = False       # True from the moment ALARM/STALE trips until Acknowledge fully clears it
+    acknowledged: bool = True   # False while a latched episode awaits acknowledge
+    peak_value: float | None = None
+    peak_timestamp: float | None = None
+    trip_timestamp: float | None = None
+    last_value: float | None = None
+    last_timestamp: float | None = None  # newest sample timestamp seen, of any value -- drives staleness
+
+
+def display_status(state: ChannelAlarmState) -> DisplayStatus:
+    '''What the GUI should actually render for this channel right now.'''
+    if state.state == AlarmState.ALARM:
+        return DisplayStatus.ALARM
+    if state.state == AlarmState.STALE:
+        return DisplayStatus.STALE
+    if state.state == AlarmState.NO_DATA:
+        return DisplayStatus.NO_DATA
+    if state.latched and not state.acknowledged:
+        return DisplayStatus.CLEARED
+    return DisplayStatus.OK
+
+
+def _breach(value, spec: AlarmSpec) -> bool:
+    if spec.high is not None and value > spec.high:
+        return True
+    if spec.low is not None and value < spec.low:
+        return True
+    if spec.abs_high is not None and abs(value) > spec.abs_high:
+        return True
+    return False
+
+
+def _cleared(value, spec: AlarmSpec) -> bool:
+    # "cleared" means back inside every deadband whose limit type is actually
+    # configured; a limit type that isn't configured never blocks clearing.
+    ok = True
+    if spec.high is not None:
+        clear_high = spec.clear_high if spec.clear_high is not None else spec.high
+        ok = ok and value <= clear_high
+    if spec.low is not None:
+        clear_low = spec.clear_low if spec.clear_low is not None else spec.low
+        ok = ok and value >= clear_low
+    if spec.abs_high is not None:
+        clear_abs_high = spec.clear_abs_high if spec.clear_abs_high is not None else spec.abs_high
+        ok = ok and abs(value) <= clear_abs_high
+    return ok
+
+
+def _worse(value, peak, spec: AlarmSpec) -> bool:
+    if peak is None:
+        return True
+    if spec.high is not None:
+        return value > peak
+    if spec.abs_high is not None:
+        return abs(value) > abs(peak)
+    if spec.low is not None:
+        return value < peak
+    return False
+
+
+def _limit_message(channel_id, spec: AlarmSpec, value) -> str:
+    if spec.high is not None and value > spec.high:
+        return f"{channel_id}: {value} > {spec.high}"
+    if spec.abs_high is not None and abs(value) > spec.abs_high:
+        return f"{channel_id}: |{value}| > {spec.abs_high}"
+    if spec.low is not None and value < spec.low:
+        return f"{channel_id}: {value} < {spec.low}"
+    return f"{channel_id}: {value} out of range"
+
+
+class AlarmEvaluator:
+    '''Owns per-channel runtime state across scans. Call evaluate_channel() once per
+    channel per scan tick -- even with an empty samples list -- so staleness keeps
+    being checked for channels with no new data.'''
+
+    def __init__(self):
+        self._states: dict[str, ChannelAlarmState] = {}
+
+    def state_for(self, channel_id: str) -> ChannelAlarmState:
+        return self._states.setdefault(channel_id, ChannelAlarmState(channel_id=channel_id))
+
+    def evaluate_channel(self, channel_id, spec: AlarmSpec | None, samples, now: float, log_interval_s: float):
+        '''samples: [(timestamp, raw_value), ...] newly arrived since the previous
+        scan, in chronological order -- every sample is folded through in order so an
+        excursion between ticks is never missed, not just the newest one. Always uses
+        the raw channel value; offset correction is a display-only concern of the
+        plot layer and must never reach here.'''
+        state = self.state_for(channel_id)
+        transitions = []
+
+        for timestamp, value in samples:
+            state.last_timestamp = timestamp
+            state.last_value = value
+            transitions += self._evaluate_sample(state, spec, value, timestamp)
+
+        transitions += self._evaluate_staleness(state, spec, now, log_interval_s)
+        return transitions
+
+    def acknowledge(self, channel_id, now: float):
+        state = self._states.get(channel_id)
+        if state is None or not state.latched:
+            return []
+
+        if state.state in (AlarmState.ALARM, AlarmState.STALE):
+            # Still actively breaching: dismiss the banner only. The tile stays
+            # colored and the condition keeps evaluating live.
+            state.acknowledged = True
+            return [AlarmTransition(channel_id=channel_id, from_state=state.state, to_state=state.state,
+                                     timestamp=now, value=state.last_value,
+                                     message=f"{channel_id}: acknowledged (still active)")]
+
+        # Already back to OK/NO_DATA and latched -- this is the "cleared,
+        # unacknowledged" case; acknowledging it fully removes the episode.
+        peak, trip = state.peak_value, state.trip_timestamp
+        state.latched = False
+        state.acknowledged = True
+        state.peak_value = None
+        state.peak_timestamp = None
+        state.trip_timestamp = None
+        return [AlarmTransition(channel_id=channel_id, from_state=state.state, to_state=state.state,
+                                 timestamp=now, value=state.last_value,
+                                 message=f"{channel_id}: acknowledged (was cleared, peak {peak} at {trip})")]
+
+    def acknowledge_all(self, now: float):
+        transitions = []
+        for channel_id in list(self._states.keys()):
+            transitions += self.acknowledge(channel_id, now)
+        return transitions
+
+    def _change_state(self, state: ChannelAlarmState, new_state: AlarmState, timestamp, value, message) -> AlarmTransition:
+        old_state = state.state
+        state.state = new_state
+        return AlarmTransition(channel_id=state.channel_id, from_state=old_state, to_state=new_state,
+                                timestamp=timestamp, value=value, message=message)
+
+    def _evaluate_sample(self, state: ChannelAlarmState, spec: AlarmSpec | None, value, timestamp):
+        transitions = []
+
+        # NaN must never satisfy an OK/ALARM comparison -- check it before any
+        # threshold math runs. An intentionally-off gauge is normal: NO_DATA never
+        # latches, and entering it drops any earlier unacknowledged episode.
+        if isinstance(value, float) and math.isnan(value):
+            if state.state != AlarmState.NO_DATA:
+                state.latched = False
+                state.acknowledged = True
+                state.peak_value = None
+                state.peak_timestamp = None
+                state.trip_timestamp = None
+                transitions.append(self._change_state(state, AlarmState.NO_DATA, timestamp, value,
+                                                        f"{state.channel_id}: no data"))
+            return transitions
+
+        if state.state == AlarmState.NO_DATA:
+            state.consecutive_breach = 0
+            transitions.append(self._change_state(state, AlarmState.OK, timestamp, value,
+                                                    f"{state.channel_id}: data resumed"))
+        elif state.state == AlarmState.STALE:
+            # A fresh sample resolves staleness immediately (no debounce needed for
+            # that). This keeps the episode latched (STALE already raised the
+            # banner) but starts a fresh "cleared, pending ack" sub-episode so the
+            # operator still sees that the feed came back, even if the still-stale
+            # condition had already been acknowledged.
+            state.consecutive_breach = 0
+            state.acknowledged = False
+            transitions.append(self._change_state(state, AlarmState.OK, timestamp, value,
+                                                    f"{state.channel_id}: data resumed after stale"))
+
+        if spec is None:
+            return transitions  # no thresholds configured for this channel
+
+        breached = _breach(value, spec)
+
+        if state.state == AlarmState.OK:
+            if breached:
+                state.consecutive_breach += 1
+                if state.consecutive_breach >= spec.consecutive_samples:
+                    state.peak_value = value
+                    state.peak_timestamp = timestamp
+                    state.trip_timestamp = timestamp
+                    state.latched = True
+                    state.acknowledged = False
+                    transitions.append(self._change_state(state, AlarmState.ALARM, timestamp, value,
+                                                            _limit_message(state.channel_id, spec, value)))
+            else:
+                state.consecutive_breach = 0
+
+        elif state.state == AlarmState.ALARM:
+            if breached:
+                if _worse(value, state.peak_value, spec):
+                    state.peak_value = value
+                    state.peak_timestamp = timestamp
+            elif _cleared(value, spec):
+                peak, trip = state.peak_value, state.trip_timestamp
+                state.consecutive_breach = 0
+                # Fresh "cleared" sub-episode: even if the active alarm had already
+                # been acknowledged, clearing re-raises the banner (this is what
+                # makes a re-trigger after clearing show up again).
+                state.acknowledged = False
+                transitions.append(self._change_state(state, AlarmState.OK, timestamp, value,
+                                                        f"{state.channel_id}: cleared, peak {peak} at {trip}"))
+            # else: inside the deadband strip between the clear and trip thresholds
+            # -- stays ALARM, no transition.
+
+        return transitions
+
+    def _evaluate_staleness(self, state: ChannelAlarmState, spec: AlarmSpec | None, now: float, log_interval_s: float):
+        if state.last_timestamp is None:
+            return []  # never seen any data at all yet -- nothing to call stale
+
+        multiplier = spec.stale_multiplier if spec is not None else AlarmSpec().stale_multiplier
+        threshold = multiplier * log_interval_s
+
+        if state.state != AlarmState.STALE and (now - state.last_timestamp) > threshold:
+            state.latched = True
+            state.acknowledged = False
+            age = now - state.last_timestamp
+            return [self._change_state(state, AlarmState.STALE, now, state.last_value,
+                                        f"{state.channel_id}: stale (no data for {age:.0f}s)")]
+        return []

--- a/core_tools/gui/data_cache.py
+++ b/core_tools/gui/data_cache.py
@@ -1,0 +1,111 @@
+import os
+import pandas as pd
+from pyqtgraph.Qt import QtCore
+
+from .get_data_for_GUI import (
+    read_last_n_rows, get_seconds_ago, get_seconds_ago_1904_epoch,
+    get_outer_vessel_gauge_pressure, get_filter_line_flowrate, get_filter_line_pressure,
+    get_filter_line_temperature, get_filter_line_H2O_concentration, get_VMM_temperature,
+)
+
+'''One disk read per file per scan tick, fanned out to every channel that needs it --
+this replaces the old design where 16 VMM plots each independently re-scanned
+vmm_temperatures.csv every tick. A DataFileCache instance is scoped to a single scan
+(constructed fresh each tick, discarded after), so it never needs eviction logic:
+each (filepath, mtime, ...) key it sees within that scan is read from disk at most
+once, and the whole cache is simply garbage collected once the tick's results have
+been reported back.'''
+
+
+class DataFileCache:
+    def __init__(self):
+        self._cache = {}
+
+    def get(self, filepath, n, delimiter=',', has_header=True, column_names=None):
+        mtime = os.path.getmtime(filepath)  # raises OSError/FileNotFoundError -- caller decides how to handle it
+        key = (filepath, mtime, delimiter, has_header, tuple(column_names) if column_names else None)
+        if key not in self._cache:
+            self._cache[key] = read_last_n_rows(filepath, n, delimiter=delimiter, has_header=has_header, column_names=column_names)
+        return self._cache[key]
+
+
+def get_n_xy_cached(cache, filepath, n, datatype, vmm_num, read_n=None):
+    '''Same (times, values) contract as get_n_XY_datapoints in get_data_for_GUI.py,
+    but sources its raw DataFrame from `cache` instead of reading the file directly.
+    `read_n` is how many rows to actually fetch from disk (the largest any caller
+    sharing this file needs this tick); `n` is how many this particular caller wants
+    sliced off the end of that shared read. VMM channels share one file across 16
+    different vmm_num filters, so each does its own in-memory filter + .tail(n)
+    against the one shared read rather than a second per-channel disk scan.'''
+    read_n = read_n if read_n is not None else n
+
+    if datatype == 'vmm_temperature':
+        raw = cache.get(filepath, read_n)
+        channel = pd.to_numeric(raw['fec'], errors='coerce') * 8 + pd.to_numeric(raw['hyb'], errors='coerce') * 2 + pd.to_numeric(raw['vmm'], errors='coerce')
+        filtered = raw[channel == vmm_num].tail(n).copy()
+        return get_seconds_ago(filtered), get_VMM_temperature(filtered)
+
+    if datatype == 'gauge_pressure':
+        raw = cache.get(filepath, read_n, delimiter='\t', has_header=False, column_names=['Time', 'Voltage'])
+        df = raw.tail(n).copy()
+        return get_seconds_ago_1904_epoch(df), df['Voltage']
+
+    raw = cache.get(filepath, read_n)
+    df = raw.tail(n).copy()
+    if datatype == 'outer_vessel_gauge_1_pressure':
+        return get_seconds_ago(df), get_outer_vessel_gauge_pressure(df, 1)
+    elif datatype == 'outer_vessel_gauge_2_pressure':
+        return get_seconds_ago(df), get_outer_vessel_gauge_pressure(df, 2)
+    elif datatype == 'filter_line_flowrate':
+        return get_seconds_ago(df), get_filter_line_flowrate(df)
+    elif datatype == 'filter_line_pressure':
+        return get_seconds_ago(df), get_filter_line_pressure(df)
+    elif datatype == 'filter_line_temperature':
+        return get_seconds_ago(df), get_filter_line_temperature(df)
+    elif datatype == 'filter_line_H2O_concentration':
+        return get_seconds_ago(df), get_filter_line_H2O_concentration(df)
+    else:
+        raise ValueError(f"Unsupported datatype: {datatype}")
+
+
+# A vmm_temperature request for n matching rows needs roughly 16x as many RAW rows
+# read from the shared file (16 channels interleaved, ~evenly), plus margin -- this
+# is a heuristic, not a guarantee; an unlucky distribution could still under-fill a
+# channel's window by a few points, which is fine (fewer displayed points, not wrong
+# data) and is why get_n_xy_cached's own .tail(n) still trims correctly either way.
+VMM_READ_SAFETY_FACTOR = 20
+
+
+class ScanWorkerSignals(QtCore.QObject):
+    finished = QtCore.pyqtSignal(dict)  # channel_id -> ('ok', x, y) | ('error', message)
+
+
+class ScanRunnable(QtCore.QRunnable):
+    '''Runs entirely on a QThreadPool worker thread: no Qt widgets, no
+    self.plotter -- pure file I/O and pandas, so it's safe off the GUI thread.
+    Results are handed back to the GUI thread via a signal, never a direct call.'''
+
+    def __init__(self, requests):
+        # requests: [(channel_id, filepath, n, datatype, vmm_num), ...]
+        super().__init__()
+        self.requests = requests
+        self.signals = ScanWorkerSignals()
+
+    def run(self):
+        cache = DataFileCache()
+
+        file_max_n = {}
+        for _channel_id, filepath, n, datatype, _vmm_num in self.requests:
+            effective_n = n * VMM_READ_SAFETY_FACTOR if datatype == 'vmm_temperature' else n
+            file_max_n[filepath] = max(file_max_n.get(filepath, 0), effective_n)
+
+        results = {}
+        for channel_id, filepath, n, datatype, vmm_num in self.requests:
+            try:
+                x, y = get_n_xy_cached(cache, filepath, n, datatype, vmm_num, read_n=file_max_n[filepath])
+            except (pd.errors.ParserError, ValueError, OSError) as e:
+                results[channel_id] = ('error', str(e))
+                continue
+            results[channel_id] = ('ok', x, y)
+
+        self.signals.finished.emit(results)

--- a/core_tools/gui/decimate.py
+++ b/core_tools/gui/decimate.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+'''Min/max-per-pixel-bucket decimation. A naive stride (take every Nth point) can
+silently hide a spike that falls between the kept samples -- unacceptable for
+alarm-relevant data -- so each bucket instead keeps its min AND max value point, in
+time order, which preserves every excursion's extremes at the cost of showing 2
+points per bucket instead of 1.'''
+
+
+def decimate_min_max(x, y, max_points=20000):
+    x = np.asarray(x)
+    y = np.asarray(y)
+    n = len(x)
+    if n <= max_points:
+        return x, y
+
+    bucket_count = max(1, max_points // 2)
+    edges = np.linspace(0, n, bucket_count + 1).astype(int)
+
+    out_x = []
+    out_y = []
+    for i in range(bucket_count):
+        start, end = edges[i], edges[i + 1]
+        if start >= end:
+            continue
+        bucket_x = x[start:end]
+        bucket_y = y[start:end]
+
+        if np.all(np.isnan(bucket_y)):
+            min_idx = max_idx = 0
+        else:
+            min_idx = np.nanargmin(bucket_y)
+            max_idx = np.nanargmax(bucket_y)
+
+        first_idx, second_idx = (min_idx, max_idx) if min_idx <= max_idx else (max_idx, min_idx)
+        out_x.append(bucket_x[first_idx])
+        out_y.append(bucket_y[first_idx])
+        if second_idx != first_idx:
+            out_x.append(bucket_x[second_idx])
+            out_y.append(bucket_y[second_idx])
+
+    return np.array(out_x), np.array(out_y)

--- a/core_tools/gui/get_data_for_GUI.py
+++ b/core_tools/gui/get_data_for_GUI.py
@@ -55,23 +55,37 @@ def read_last_n_rows_filtered(data_filepath, n, vmm_num, chunk_size=65536, delim
         file_size = f.tell()
 
         pos = file_size
-        chunks = []
-        matched = []
+        matched = []  # kept in chronological order by prepending each (older) chunk's finds
+        carry = b''   # partial line fragment at the front of what's been processed so far
 
         while pos > len(header) and len(matched) < n:
             read_size = min(chunk_size, pos - len(header))
             pos -= read_size
             f.seek(pos)
             chunk = f.read(read_size)
-            chunks.append(chunk)
 
-            # re-filter everything read so far each time, working from
-            # the current back-position to the end of the file
-            tail_bytes = b''.join(reversed(chunks))
-            all_lines = tail_bytes.splitlines()
+            # Only the bytes just read are new; everything after them was already
+            # filtered in a previous iteration and must not be re-scanned (that
+            # re-scan of all accumulated bytes on every iteration was the O(n^2)
+            # bug -- each byte is now split/filtered exactly once).
+            combined = chunk + carry
+            split_lines = combined.split(b'\n')
 
-            matched = []
-            for line in all_lines:
+            if pos > len(header):
+                # The first fragment may itself be an incomplete line whose true
+                # start is further back in the file (not yet read) -- hold it for
+                # the next (older) iteration instead of matching against it now.
+                carry = split_lines[0]
+                new_lines = split_lines[1:]
+            else:
+                # This chunk starts exactly at the beginning of the data -- its
+                # first fragment is a genuine complete line.
+                carry = b''
+                new_lines = split_lines
+
+            this_chunk_matches = []
+            for line in new_lines:
+                line = line.rstrip(b'\r')  # tolerate \r\n line endings from external writers
                 parts = line.split(delimiter.encode())
                 if len(parts) < 5:
                     continue
@@ -80,7 +94,11 @@ def read_last_n_rows_filtered(data_filepath, n, vmm_num, chunk_size=65536, delim
                 except ValueError:
                     continue
                 if fec * 8 + hyb * 2 + vmm == vmm_num:
-                    matched.append(line)
+                    this_chunk_matches.append(line)
+
+            # This chunk is older than everything already in matched, so its finds
+            # go at the front to keep the overall list chronological.
+            matched = this_chunk_matches + matched
 
     lines = matched[-n:] if n > 0 else []
 
@@ -100,14 +118,21 @@ def get_seconds_ago(dataframe):
     else:
         raise ValueError("DataFrame must contain either a 'Time' or 'timestamp' column")
 
-    # Get the current time as a datetime object
-    current_time = datetime.now()
+    # These timestamps are written by time.strftime(...) (see
+    # save_pressure_readings_functions.py / save_H2O_sensor_readings_functions.py),
+    # which is naive local time -- so treat them as local time explicitly (tz-aware)
+    # rather than relying on an implicit, unstated "naive means local" convention.
+    # This keeps the arithmetic unambiguous regardless of the machine's timezone
+    # (e.g. a Windows box set to Pacific/Honolulu), matching the explicitly
+    # UTC-aware handling in get_seconds_ago_1904_epoch below.
+    current_time = datetime.now().astimezone()
+    local_timestamps = dataframe['timestamp'].dt.tz_localize(current_time.tzinfo)
 
     # Calculate the time difference between current_time and each timestamp in seconds
     # The subtraction produces a timedelta object, and .dt.total_seconds() converts it to float seconds
     # The negative sign (-) in front makes the value represent "seconds ago" as a negative number,
     # meaning past times will be negative
-    dataframe['seconds_ago'] = -(current_time - dataframe['timestamp']).dt.total_seconds()
+    dataframe['seconds_ago'] = -(current_time - local_timestamps).dt.total_seconds()
 
     # Return the new 'seconds_ago' Series from the dataframe
     return dataframe['seconds_ago']

--- a/core_tools/gui/live_plotter_GUI_class.py
+++ b/core_tools/gui/live_plotter_GUI_class.py
@@ -3,15 +3,18 @@ import pyqtgraph as pg
 import sys
 import pandas as pd
 import subprocess
-import shlex
+import threading
 import platform
+import serial.tools.list_ports
 
 from .get_data_for_GUI import get_n_XY_datapoints
-from .models import Channel, Plot
+from .models import Channel, Plot, LoggerControl
 
 '''Class to handle live plotting and add various controls/buttons in a Qt GUI application.'''
 
 COLOR_CYCLE = ['y', 'c', 'm', 'r', 'g', 'b', 'w']
+
+LED_COLORS = {'running': '#2ecc71', 'stopped': '#95a5a6', 'crashed': '#e74c3c'}
 
 
 class LivePlotter:
@@ -27,9 +30,18 @@ class LivePlotter:
         self.main_window.setCentralWidget(self.main_widget)
         self.main_window.setWindowTitle(win_title)
 
-        # Add a tab widget to the main layout
+        # Tabs (left) and the persistent control dock (right) sit side by side and stay
+        # visible regardless of which tab is selected -- same treatment as the status
+        # strip/banner/event log, which live in main_layout above/below this splitter.
         self.tabs = QtWidgets.QTabWidget()
-        self.main_layout.addWidget(self.tabs)
+        self.control_dock = ControlDock(self)
+
+        self.main_splitter = QtWidgets.QSplitter(QtCore.Qt.Horizontal)
+        self.main_splitter.addWidget(self.tabs)
+        self.main_splitter.addWidget(self.control_dock)
+        self.main_splitter.setStretchFactor(0, 4)
+        self.main_splitter.setStretchFactor(1, 1)
+        self.main_layout.addWidget(self.main_splitter)
 
         self.tab_objects = {}  # tab_name -> LiveTab object
         self.channels = {}     # channel_id -> Channel, registered once, shared across all tabs
@@ -54,10 +66,9 @@ class LivePlotter:
         self.tabs.addTab(tab, tab_name)
         return tab
 
-    # Call cleanup function for each tab to end all running subprocesses
+    # End all running logger subprocesses
     def cleanup(self):
-        for tab_name in self.tab_objects:
-            self.tab_objects[tab_name].cleanup()
+        self.control_dock.cleanup()
 
     # Show the window and start the event loop
     def run(self):
@@ -90,13 +101,6 @@ class LiveTab(QtWidgets.QWidget):
         self.plot_counts = 0
 
         self.plots = {}  # plot_id -> Plot (identity/config/runtime all in one place)
-
-        # Internal state tracking for command buttons (superseded by add_logger_control soon)
-        self.cmd_buttons = {}             # title -> QPushButton for terminal commands
-        self.cmd_processes = {}           # title -> subprocess.Popen object for running commands
-        self.cmd_running_state = {}       # title -> bool: is command running
-        self.cmd_command_strings = {}     # title -> command string (useful if we want to change command on the fly)
-        self.cmd_status_timer = None      # QTimer polling check_command_status, held to prevent garbage collection
 
         # Internal state tracking for dropdown menus
         self.dd_menus = {}
@@ -218,100 +222,13 @@ class LiveTab(QtWidgets.QWidget):
             plot.start_stop_button.setStyleSheet("background-color: red;")
             plot.running = True
 
-    # Run a terminal command using subprocess
-    def run_terminal_command(self, title, command):
-        system = platform.system()
-
-        if system == 'Windows':
-            # Use shlex.split to safely split the command respecting shell syntax
-            cmd_parts = shlex.split(command, posix=False)  # Use posix=False for Windows compatibility
-            process = subprocess.Popen(cmd_parts, shell=True)  # Use shell=True for Windows to handle commands correctly
-        else:
-            cmd_parts = shlex.split(command)
-            process = subprocess.Popen(cmd_parts)
-
-        self.cmd_processes[title] = process
-
-    # Terminate a running terminal command
-    def stop_terminal_command(self, title):
-        process = self.cmd_processes[title]
-
-        # Check if the process is still running and terminate it
-        if process and process.poll() is None:
-            system = platform.system()
-            if system == 'Windows':
-                subprocess.run(['taskkill', '/PID', str(process.pid), '/T', '/F'], check=True)
-            else:
-                process.kill()
-
-    # Handle button click for starting/stopping terminal commands
-    def cmd_button_clicked(self, title):
-        command = self.cmd_command_strings[title]  # this method allows us to dynamically change the command if necessary
-        if self.cmd_running_state[title]:
-            # If the command is running, stop it
-            self.stop_terminal_command(title)
-
-            cmd_button = self.cmd_buttons[title]
-            cmd_button.setText(f'Start {title}')
-            cmd_button.setStyleSheet("background-color: green;")
-
-            self.cmd_running_state[title] = False
-        else:
-            # If the command is not running, start it
-            self.run_terminal_command(title, command)
-
-            cmd_button = self.cmd_buttons[title]
-            cmd_button.setText(f'Stop {title}')
-            cmd_button.setStyleSheet("background-color: red;")
-
-            self.cmd_running_state[title] = True
-
-    # Add a button that runs a terminal command on click
-    def add_command_button(self, title, command):
-        index = self.plot_counts
-        plots_per_row = self.plots_per_row
-        self.plot_counts += 1
-        row = index // plots_per_row
-        col = index % plots_per_row
-
-        # Vertical layout to hold the plot and button
-        container = QtWidgets.QVBoxLayout()
-
-        # Create button
-        cmd_button = QtWidgets.QPushButton(f'Start {title}')
-        cmd_button.setStyleSheet("background-color: green;")
-        self.cmd_command_strings[title] = command
-        cmd_button.clicked.connect(lambda _, t=title: self.cmd_button_clicked(t))
-        self.cmd_buttons[title] = cmd_button
-
-        # Add button to vertical container
-        container.addWidget(cmd_button)
-
-        # Wrap the layout in a QWidget and add it to the grid
-        container_widget = QtWidgets.QWidget()
-        container_widget.setLayout(container)
-        self.layout.addWidget(container_widget, row, col)
-
-        # Mark the command as not running
-        self.cmd_running_state[title] = False
-
-    # Check the status of all command processes and update button states
-    def check_command_status(self):
-        for title in self.cmd_processes:
-            process = self.cmd_processes[title]
-            if process.poll() is not None:
-                # Process has finished, update button state
-                cmd_button = self.cmd_buttons[title]
-                cmd_button.setText(f'Start {title}')
-                cmd_button.setStyleSheet("background-color: green;")
-                self.cmd_running_state[title] = False
-
-    def cmd_timer(self, interval_ms):
-        # Create a timer to check command status on a regular interval
-        timer = QtCore.QTimer()
-        timer.timeout.connect(lambda: self.check_command_status())
-        timer.start(interval_ms)
-        self.cmd_status_timer = timer  # held to prevent garbage collection
+    # Register a logger's controls (LED, port, interval, start/stop) in the shared
+    # control dock -- see ControlDock.add_logger_group for what this actually builds.
+    def add_logger_control(self, id, label, script, log_filepath, port, interval_options, default_interval):
+        return self.plotter.control_dock.add_logger_group(
+            id=id, label=label, script=script, log_filepath=log_filepath, port=port,
+            interval_options=interval_options, default_interval=default_interval,
+        )
 
     # Add a dropdown menu with specified options and values attached to the options
     def add_dropdown_menu(self, title, option_names, option_values, ctrl_var=None, on_change_callback=None):
@@ -355,33 +272,190 @@ class LiveTab(QtWidgets.QWidget):
         container_widget.setMaximumWidth(500)  # prevent stretching (aesthetics)
         self.layout.addWidget(container_widget, row, col)
 
-    # Changes the command string associated with a specified command button based on the title of the button
-    def change_cmd_button_command(self, title, new_command):
-        self.cmd_command_strings[title] = new_command
-
-    # Specialized function specifically for the 40L TPC commands, will likely not be useful for a general user of this program
-    # People using this program for a different use case will need to edit this function and/or write a new one to do the editing they need to the command string
-    def change_cmd(self, title, ctrl_title, dropdown_text, new_option_value):
-        old_command = self.cmd_command_strings[ctrl_title]
-
-        parts = old_command.split()
-        parts[-1] = str(new_option_value)
-
-        new_command = ' '.join(parts)
-
-        print(f'New Command: {new_command}')  # for debugging
-
-        self.change_cmd_button_command(ctrl_title, new_command)
-
     # Change the buffer size of multiple plots at once, intended to be attached to a dropdown menu.
     # ctrl_plot_ids is a list of plot_ids that correspond to the plots to change.
     def change_buffer_size_multiple(self, title, ctrl_plot_ids, dropdown_text, new_option_value):
         for plot_id in ctrl_plot_ids:
             self.plots[str(plot_id)].buffer_size = new_option_value
 
-    # End all running subprocesses
+
+class ControlDock(QtWidgets.QWidget):
+    '''Persistent right-hand dock, visible regardless of which tab is selected. Owns
+    every logger's structured subprocess lifecycle (LED, port/interval dropdowns,
+    start/stop, crash reporting) -- LiveTab.add_logger_control() just forwards here.'''
+
+    def __init__(self, plotter):
+        super().__init__()
+        self.plotter = plotter
+        self.loggers = {}  # id -> LoggerControl
+
+        self.layout = QtWidgets.QVBoxLayout()
+        self.setLayout(self.layout)
+
+        self.loggers_layout = QtWidgets.QVBoxLayout()
+        self.layout.addLayout(self.loggers_layout)
+        self.layout.addStretch(1)
+
+        # Polls every logger's subprocess for an unexpected exit; this is deliberately
+        # decoupled from any single logger's own start/stop so a crash is caught even
+        # if nothing else touches that logger's controls.
+        self._status_timer = QtCore.QTimer()
+        self._status_timer.timeout.connect(self._poll_loggers)
+        self._status_timer.start(500)
+
+    def _set_led(self, logger, state):
+        logger.led.setStyleSheet(f"background-color: {LED_COLORS[state]}; border-radius: 6px;")
+
+    # Build one logger's group box: LED, port dropdown (from the live serial port
+    # list, defaulting to the declared port), interval dropdown, start/stop button,
+    # and a hidden error line that appears only on an unexpected exit.
+    def add_logger_group(self, id, label, script, log_filepath, port, interval_options, default_interval):
+        logger = LoggerControl(
+            id=id, label=label, script=script, log_filepath=log_filepath,
+            interval_options=interval_options, default_interval=default_interval, port=port,
+        )
+
+        box = QtWidgets.QGroupBox(label)
+        box_layout = QtWidgets.QVBoxLayout()
+        box.setLayout(box_layout)
+
+        status_row = QtWidgets.QHBoxLayout()
+        led = QtWidgets.QLabel()
+        led.setFixedSize(12, 12)
+        logger.led = led
+        status_row.addWidget(led)
+        status_row.addWidget(QtWidgets.QLabel(label))
+        status_row.addStretch(1)
+        box_layout.addLayout(status_row)
+
+        port_combo = QtWidgets.QComboBox()
+        available_ports = [p.device for p in serial.tools.list_ports.comports()]
+        if port not in available_ports:
+            available_ports = [port] + available_ports
+        port_combo.addItems(available_ports)
+        port_combo.setCurrentText(port)
+        logger.port_combo = port_combo
+        box_layout.addWidget(port_combo)
+
+        interval_combo = QtWidgets.QComboBox()
+        default_index = 0
+        for i, (option_label, option_value) in enumerate(interval_options):
+            interval_combo.addItem(option_label, userData=option_value)
+            if option_value == default_interval:
+                default_index = i
+        interval_combo.setCurrentIndex(default_index)
+        interval_combo.currentIndexChanged.connect(lambda idx, lid=id: self._interval_changed(lid, idx))
+        logger.interval_combo = interval_combo
+        box_layout.addWidget(interval_combo)
+
+        error_label = QtWidgets.QLabel('')
+        error_label.setStyleSheet('color: #e74c3c; font-size: 10px;')
+        error_label.setWordWrap(True)
+        error_label.hide()
+        logger.error_label = error_label
+        box_layout.addWidget(error_label)
+
+        start_stop_button = QtWidgets.QPushButton(f'Start {label}')
+        start_stop_button.setStyleSheet("background-color: green;")
+        start_stop_button.clicked.connect(lambda _, lid=id: self._toggle_logger(lid))
+        logger.start_stop_button = start_stop_button
+        box_layout.addWidget(start_stop_button)
+
+        self.loggers[id] = logger
+        self._set_led(logger, 'stopped')
+        self.loggers_layout.addWidget(box)
+        return logger
+
+    # Changing the interval while a logger is running must not silently do nothing:
+    # stash it and apply on the next start, rather than restarting the process here.
+    def _interval_changed(self, logger_id, idx):
+        logger = self.loggers[logger_id]
+        new_value = logger.interval_combo.itemData(idx)
+        if logger.running:
+            logger.pending_interval = new_value
+            print(f"[{logger.label}] interval change to {logger.interval_combo.itemText(idx)} will apply on next start")
+        else:
+            logger.pending_interval = None
+
+    def _toggle_logger(self, logger_id):
+        logger = self.loggers[logger_id]
+        if logger.running:
+            self._stop_logger(logger)
+        else:
+            self._start_logger(logger)
+
+    def _start_logger(self, logger):
+        interval = logger.pending_interval if logger.pending_interval is not None else logger.interval_combo.currentData()
+        port = logger.port_combo.currentText()
+        # argv is a real list -- never a shell string -- so filenames/ports with
+        # spaces need no special handling, and sys.executable ensures the venv
+        # interpreter (not a bare 'python' off PATH) runs the logger.
+        argv = [sys.executable, logger.script, logger.log_filepath, port, str(interval)]
+
+        process = subprocess.Popen(argv, stderr=subprocess.PIPE, text=True, bufsize=1)
+        logger.process = process
+        logger.user_stopped = False
+        logger.stderr_lines = []
+        logger.pending_interval = None
+
+        # Read stderr on a background thread so the GUI thread never blocks on it;
+        # captured lines are surfaced on an unexpected exit (see _poll_loggers).
+        thread = threading.Thread(target=self._read_stderr, args=(logger,), daemon=True)
+        thread.start()
+
+        logger.running = True
+        logger.start_stop_button.setText(f'Stop {logger.label}')
+        logger.start_stop_button.setStyleSheet("background-color: red;")
+        logger.error_label.hide()
+        self._set_led(logger, 'running')
+
+    def _read_stderr(self, logger):
+        process = logger.process
+        if process.stderr is None:
+            return
+        for line in process.stderr:
+            line = line.rstrip('\n')
+            if line:
+                logger.stderr_lines.append(line)
+                if len(logger.stderr_lines) > 200:
+                    logger.stderr_lines.pop(0)
+                print(f"[{logger.label} stderr] {line}")  # routed to the real event log in a later commit
+
+    def _stop_logger(self, logger):
+        logger.user_stopped = True
+        self._kill(logger.process)
+        logger.running = False
+        logger.start_stop_button.setText(f'Start {logger.label}')
+        logger.start_stop_button.setStyleSheet("background-color: green;")
+        self._set_led(logger, 'stopped')
+
+    @staticmethod
+    def _kill(process):
+        if process and process.poll() is None:
+            if platform.system() == 'Windows':
+                subprocess.run(['taskkill', '/PID', str(process.pid), '/T', '/F'], check=True)
+            else:
+                process.kill()
+
+    # Never silently flip a crashed logger's button back to "everything is fine" --
+    # an unexpected exit gets a red LED and the last captured stderr line.
+    def _poll_loggers(self):
+        for logger in self.loggers.values():
+            if logger.running and logger.process is not None and logger.process.poll() is not None:
+                exit_code = logger.process.returncode
+                logger.running = False
+                logger.start_stop_button.setText(f'Start {logger.label}')
+                logger.start_stop_button.setStyleSheet("background-color: green;")
+                if logger.user_stopped:
+                    self._set_led(logger, 'stopped')
+                else:
+                    self._set_led(logger, 'crashed')
+                    last_line = logger.stderr_lines[-1] if logger.stderr_lines else '(no stderr captured)'
+                    logger.error_label.setText(f'exit code {exit_code}: {last_line}')
+                    logger.error_label.show()
+                    print(f"Logger {logger.label} exited unexpectedly (code {exit_code}): {last_line}")  # routed to the real event log in a later commit
+
     def cleanup(self):
-        for title in self.cmd_processes:
-            process = self.cmd_processes[title]
-            if process.poll() is None:
-                self.stop_terminal_command(title)
+        for logger in self.loggers.values():
+            logger.user_stopped = True
+            self._kill(logger.process)

--- a/core_tools/gui/live_plotter_GUI_class.py
+++ b/core_tools/gui/live_plotter_GUI_class.py
@@ -78,12 +78,13 @@ class LivePlotter:
         self.channels = {}     # channel_id -> Channel, registered once, shared across all tabs
         self.channel_plots = {}  # channel_id -> [(LiveTab, plot_id), ...], for alarm-driven visuals
 
+        self.settings = QtCore.QSettings('40L-TPC', 'RunControlGUI')
+        self.event_log = EventLog()
+
         # Alarm banner (hidden when nothing is active) and the status strip are
         # always visible above the tabs, regardless of which tab is selected.
         self.alarm_banner = AlarmBanner(self)
-        self.main_layout.addWidget(self.alarm_banner)
         self.status_strip = StatusStrip(self)
-        self.main_layout.addWidget(self.status_strip)
 
         # Tabs (left) and the persistent control dock (right) sit side by side and
         # also stay visible regardless of which tab is selected.
@@ -95,7 +96,26 @@ class LivePlotter:
         self.main_splitter.addWidget(self.control_dock)
         self.main_splitter.setStretchFactor(0, 4)
         self.main_splitter.setStretchFactor(1, 1)
-        self.main_layout.addWidget(self.main_splitter)
+
+        top_widget = QtWidgets.QWidget()
+        top_layout = QtWidgets.QVBoxLayout()
+        top_layout.setContentsMargins(0, 0, 0, 0)
+        top_widget.setLayout(top_layout)
+        top_layout.addWidget(self.alarm_banner)
+        top_layout.addWidget(self.status_strip)
+        top_layout.addWidget(self.main_splitter)
+
+        # The control dock and the event log pane are the two collapsible regions
+        # (drag the splitter handle to 0 to collapse); the banner/strip/tabs above
+        # them are always visible instead, same as the doc's mockup.
+        self.outer_splitter = QtWidgets.QSplitter(QtCore.Qt.Vertical)
+        self.outer_splitter.addWidget(top_widget)
+        self.outer_splitter.addWidget(self.event_log)
+        self.outer_splitter.setStretchFactor(0, 4)
+        self.outer_splitter.setStretchFactor(1, 1)
+        self.main_layout.addWidget(self.outer_splitter)
+
+        self._restore_layout()
 
         # Alarm evaluation is driven by one scanner timer here, independent of any
         # plot's own timer/pause state (see core_tools/alarms.py and §4.4).
@@ -107,6 +127,21 @@ class LivePlotter:
 
         # Calls the cleanup function when the application is about to quit so that all running subprocesses are terminated
         self.app.aboutToQuit.connect(self.cleanup)
+
+    def log(self, message, level='INFO'):
+        self.event_log.add_line(level, message)
+
+    def _restore_layout(self):
+        outer_sizes = self.settings.value('outer_splitter_sizes')
+        if outer_sizes:
+            self.outer_splitter.setSizes([int(s) for s in outer_sizes])
+        main_sizes = self.settings.value('main_splitter_sizes')
+        if main_sizes:
+            self.main_splitter.setSizes([int(s) for s in main_sizes])
+
+    def _save_layout(self):
+        self.settings.setValue('outer_splitter_sizes', self.outer_splitter.sizes())
+        self.settings.setValue('main_splitter_sizes', self.main_splitter.sizes())
 
     # Register a data source once so it can be referenced by id from any tab's plots,
     # read for the status strip, or evaluated for alarms -- with or without a plot.
@@ -141,7 +176,10 @@ class LivePlotter:
                     samples.append((ts, float(value)))
             samples.sort(key=lambda s: s[0])
 
-            self.alarm_evaluator.evaluate_channel(channel_id, channel.alarm, samples, now, channel.log_interval_s)
+            transitions = self.alarm_evaluator.evaluate_channel(channel_id, channel.alarm, samples, now, channel.log_interval_s)
+            for transition in transitions:
+                level = 'ALARM' if transition.to_state in (AlarmState.ALARM, AlarmState.STALE) else 'INFO'
+                self.log(transition.message, level=level)
             if newest_ts is not None:
                 self._alarm_last_ts[channel_id] = newest_ts
 
@@ -225,7 +263,9 @@ class LivePlotter:
 
     # End all running logger subprocesses
     def cleanup(self):
+        self._save_layout()
         self.control_dock.cleanup()
+        self.event_log.close_file()
 
     # Show the window and start the event loop
     def run(self):
@@ -378,7 +418,7 @@ class LiveTab(QtWidgets.QWidget):
             try:
                 x_data, y_data = get_n_XY_datapoints(channel.filepath, plot.buffer_size, channel.datatype, channel.vmm_num)
             except (pd.errors.ParserError, ValueError) as e:
-                print(f"[{plot.title}] update failed: {e}")
+                self.plotter.log(f"[{plot.title}] update failed: {e}", level='ERROR')
                 continue
 
             plot.curves[i].setData(x=x_data, y=y_data + float(offset))
@@ -484,6 +524,11 @@ class ControlDock(QtWidgets.QWidget):
     every logger's structured subprocess lifecycle (LED, port/interval dropdowns,
     start/stop, crash reporting) -- LiveTab.add_logger_control() just forwards here.'''
 
+    # stderr is read on a background thread (see _read_stderr); a signal is the only
+    # safe way to hand a line back to the GUI thread for logging/widget updates --
+    # Qt widgets must never be touched directly from a non-GUI thread.
+    stderr_line_received = QtCore.pyqtSignal(str, str)  # logger_id, line
+
     def __init__(self, plotter):
         super().__init__()
         self.plotter = plotter
@@ -495,6 +540,8 @@ class ControlDock(QtWidgets.QWidget):
         self.loggers_layout = QtWidgets.QVBoxLayout()
         self.layout.addLayout(self.loggers_layout)
         self.layout.addStretch(1)
+
+        self.stderr_line_received.connect(self._on_stderr_line)
 
         # Polls every logger's subprocess for an unexpected exit; this is deliberately
         # decoupled from any single logger's own start/stop so a crash is caught even
@@ -573,7 +620,7 @@ class ControlDock(QtWidgets.QWidget):
         new_value = logger.interval_combo.itemData(idx)
         if logger.running:
             logger.pending_interval = new_value
-            print(f"[{logger.label}] interval change to {logger.interval_combo.itemText(idx)} will apply on next start")
+            self.plotter.log(f"[{logger.label}] interval change to {logger.interval_combo.itemText(idx)} will apply on next start", level='INFO')
         else:
             logger.pending_interval = None
 
@@ -608,18 +655,27 @@ class ControlDock(QtWidgets.QWidget):
         logger.start_stop_button.setStyleSheet("background-color: red;")
         logger.error_label.hide()
         self._set_led(logger, 'running')
+        self.plotter.log(f"Started logger: {logger.label} ({port}, {interval}s)", level='INFO')
 
     def _read_stderr(self, logger):
+        # Runs on a background thread -- must not touch Qt widgets or self.plotter
+        # directly. Emitting a signal marshals the call onto the GUI thread.
         process = logger.process
         if process.stderr is None:
             return
         for line in process.stderr:
             line = line.rstrip('\n')
             if line:
-                logger.stderr_lines.append(line)
-                if len(logger.stderr_lines) > 200:
-                    logger.stderr_lines.pop(0)
-                print(f"[{logger.label} stderr] {line}")  # routed to the real event log in a later commit
+                self.stderr_line_received.emit(logger.id, line)
+
+    def _on_stderr_line(self, logger_id, line):
+        logger = self.loggers.get(logger_id)
+        if logger is None:
+            return
+        logger.stderr_lines.append(line)
+        if len(logger.stderr_lines) > 200:
+            logger.stderr_lines.pop(0)
+        self.plotter.log(f"[{logger.label}] {line}", level='ERROR')
 
     def _stop_logger(self, logger):
         logger.user_stopped = True
@@ -628,6 +684,7 @@ class ControlDock(QtWidgets.QWidget):
         logger.start_stop_button.setText(f'Start {logger.label}')
         logger.start_stop_button.setStyleSheet("background-color: green;")
         self._set_led(logger, 'stopped')
+        self.plotter.log(f"Stopped logger: {logger.label}", level='INFO')
 
     @staticmethod
     def _kill(process):
@@ -653,7 +710,7 @@ class ControlDock(QtWidgets.QWidget):
                     last_line = logger.stderr_lines[-1] if logger.stderr_lines else '(no stderr captured)'
                     logger.error_label.setText(f'exit code {exit_code}: {last_line}')
                     logger.error_label.show()
-                    print(f"Logger {logger.label} exited unexpectedly (code {exit_code}): {last_line}")  # routed to the real event log in a later commit
+                    self.plotter.log(f"Logger {logger.label} exited unexpectedly (code {exit_code}): {last_line}", level='ERROR')
 
     def cleanup(self):
         for logger in self.loggers.values():
@@ -821,9 +878,76 @@ class AlarmBanner(QtWidgets.QWidget):
 
     def _on_acknowledge(self):
         if self._current_channel_id is not None:
-            self.plotter.alarm_evaluator.acknowledge(self._current_channel_id, now=time.time())
+            for transition in self.plotter.alarm_evaluator.acknowledge(self._current_channel_id, now=time.time()):
+                self.plotter.log(transition.message, level='INFO')
             self.refresh(time.time())
 
     def _on_acknowledge_all(self):
-        self.plotter.alarm_evaluator.acknowledge_all(now=time.time())
+        for transition in self.plotter.alarm_evaluator.acknowledge_all(now=time.time()):
+            self.plotter.log(transition.message, level='INFO')
         self.refresh(time.time())
+
+
+class EventLog(QtWidgets.QWidget):
+    '''Read-only, filterable, collapsible log pane at the bottom of the window.
+    Every line is also mirrored to a timestamped file on disk (flushed on every
+    write) so the log survives a GUI crash, same as the data logs it sits next to.'''
+
+    MAX_LINES = 5000
+
+    def __init__(self):
+        super().__init__()
+        self._lines = []  # formatted strings, capped at MAX_LINES, independent of the active filter
+
+        layout = QtWidgets.QVBoxLayout()
+        self.setLayout(layout)
+
+        toolbar = QtWidgets.QHBoxLayout()
+        self.filter_box = QtWidgets.QLineEdit()
+        self.filter_box.setPlaceholderText('Filter…')
+        self.filter_box.textChanged.connect(self._render)
+        toolbar.addWidget(self.filter_box)
+        copy_button = QtWidgets.QPushButton('Copy visible to clipboard')
+        copy_button.clicked.connect(self._copy_visible)
+        toolbar.addWidget(copy_button)
+        layout.addLayout(toolbar)
+
+        self.text_edit = QtWidgets.QPlainTextEdit()
+        self.text_edit.setReadOnly(True)
+        self.text_edit.setMaximumBlockCount(self.MAX_LINES)
+        layout.addWidget(self.text_edit)
+
+        filename = f"event_log_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
+        self._file = open(filename, 'a', encoding='utf-8')
+
+    def add_line(self, level, message):
+        timestamp = datetime.datetime.now().strftime('%H:%M:%S')
+        line = f"{timestamp}  {level:<5}  {message}"
+
+        self._lines.append(line)
+        if len(self._lines) > self.MAX_LINES:
+            self._lines = self._lines[-self.MAX_LINES:]
+
+        self._file.write(line + '\n')
+        self._file.flush()
+
+        if self._matches_filter(line):
+            self.text_edit.appendPlainText(line)
+
+    def _matches_filter(self, line):
+        needle = self.filter_box.text().strip().lower()
+        return not needle or needle in line.lower()
+
+    def _render(self):
+        needle = self.filter_box.text().strip().lower()
+        visible = [line for line in self._lines if not needle or needle in line.lower()]
+        self.text_edit.setPlainText('\n'.join(visible))
+
+    def _copy_visible(self):
+        QtWidgets.QApplication.clipboard().setText(self.text_edit.toPlainText())
+
+    def close_file(self):
+        try:
+            self._file.close()
+        except OSError:
+            pass

--- a/core_tools/gui/live_plotter_GUI_class.py
+++ b/core_tools/gui/live_plotter_GUI_class.py
@@ -1,14 +1,18 @@
 from pyqtgraph.Qt import QtWidgets, QtCore
 import pyqtgraph as pg
-import numpy as np
 import sys
 import pandas as pd
-from .get_data_for_GUI import get_n_XY_datapoints
 import subprocess
 import shlex
 import platform
 
+from .get_data_for_GUI import get_n_XY_datapoints
+from .models import Channel, Plot
+
 '''Class to handle live plotting and add various controls/buttons in a Qt GUI application.'''
+
+COLOR_CYCLE = ['y', 'c', 'm', 'r', 'g', 'b', 'w']
+
 
 class LivePlotter:
     def __init__(self, win_title):
@@ -28,33 +32,44 @@ class LivePlotter:
         self.main_layout.addWidget(self.tabs)
 
         self.tab_objects = {}  # tab_name -> LiveTab object
+        self.channels = {}     # channel_id -> Channel, registered once, shared across all tabs
 
-        #Calls the clanup function when the application is about to quit so that all running subprocesses are terminated
+        # Calls the cleanup function when the application is about to quit so that all running subprocesses are terminated
         self.app.aboutToQuit.connect(self.cleanup)
 
-    #Create a tab in the window to put plots and buttons in
+    # Register a data source once so it can be referenced by id from any tab's plots,
+    # read for the status strip, or evaluated for alarms -- with or without a plot.
+    def add_channel(self, id, label, long_label, filepath, datatype, units, log_interval_s, alarm=None, vmm_num=None):
+        channel = Channel(
+            id=id, label=label, long_label=long_label, filepath=filepath, datatype=datatype,
+            units=units, log_interval_s=log_interval_s, alarm=alarm, vmm_num=vmm_num,
+        )
+        self.channels[id] = channel
+        return channel
+
+    # Create a tab in the window to put plots and buttons in
     def create_tab(self, tab_name, plots_per_row):
-        tab = LiveTab(plots_per_row)
+        tab = LiveTab(plots_per_row, plotter=self)
         self.tab_objects[tab_name] = tab
         self.tabs.addTab(tab, tab_name)
         return tab
 
-    #Call cleanup function for each tab to end all running subprocesses
+    # Call cleanup function for each tab to end all running subprocesses
     def cleanup(self):
         for tab_name in self.tab_objects:
             self.tab_objects[tab_name].cleanup()
-    
+
     # Show the window and start the event loop
     def run(self):
         self.main_window.show()
         sys.exit(self.app.exec_())
 
-class LiveTab(QtWidgets.QWidget):
-    def __init__(self, plots_per_row):
-        super().__init__() # Call the constructor of the parent class (QWidget) to properly initialize the widget. This class is now a custom QTWidget
 
-        '''self.layout = QtWidgets.QGridLayout() ## Create a grid layout manager to arrange child widgets (plots, buttons) in a grid format.
-        self.setLayout(self.layout)'''
+class LiveTab(QtWidgets.QWidget):
+    def __init__(self, plots_per_row, plotter):
+        super().__init__()  # Call the constructor of the parent class (QWidget) to properly initialize the widget. This class is now a custom QTWidget
+
+        self.plotter = plotter  # back-reference, needed to resolve channel ids
 
         # Create a scroll area
         scroll = QtWidgets.QScrollArea()
@@ -74,36 +89,38 @@ class LiveTab(QtWidgets.QWidget):
         self.plots_per_row = plots_per_row
         self.plot_counts = 0
 
-        # Internal state tracking for plots
-        self.data = {}                            # title -> {x: pandas Series, y: pandas Series, buffer_size: int} (list)
-        self.offsets = {}                         # title -> y-offset value (float)
-        self.curves = {}                          # title -> plot curves (list)
-        self.interval_timers = {}                 # title -> QTimer for updates
-        self.elapsed_timers = {}                  # title -> QElapsedTimer for time axis
-        self.running_state = {}                   # title -> bool: is plot running
-        self.start_stop_buttons = {}              # title -> start/stop QPushButton
-        self.data_filepaths = {}                   # title -> data filepaths from logging to pull data from (list)
-        self.datatype = {}                        # Datatype for the plots (e.g., 'pressure', 'temperature')
-        self.vmm_nums = {}                         # title -> VMM numbers (int), only applicable for temperature plots
+        self.plots = {}  # plot_id -> Plot (identity/config/runtime all in one place)
 
-        #Internal state tracking for command buttons
-        self.cmd_buttons = {}                     # title -> QPushButton for terminal commands
-        self.cmd_processes = {}                   # title -> subprocess.Popen object for running commands
-        self.cmd_running_state = {}               # title -> bool: is command running
-        self.cmd_command_strings = {}             # title -> command string (useful if we want to change command on the fly)
+        # Internal state tracking for command buttons (superseded by add_logger_control soon)
+        self.cmd_buttons = {}             # title -> QPushButton for terminal commands
+        self.cmd_processes = {}           # title -> subprocess.Popen object for running commands
+        self.cmd_running_state = {}       # title -> bool: is command running
+        self.cmd_command_strings = {}     # title -> command string (useful if we want to change command on the fly)
+        self.cmd_status_timer = None      # QTimer polling check_command_status, held to prevent garbage collection
 
-        #Internal state tracking for dropdown menus
-        self.dd_menus = {}                        # title ->
-        self.dd_option_names = {}                 # title ->
-        self.dd_option_values = {}                # title ->
-    
+        # Internal state tracking for dropdown menus
+        self.dd_menus = {}
+        self.dd_option_names = {}
+        self.dd_option_values = {}
+
+    def _channel(self, channel_id):
+        return self.plotter.channels[channel_id]
+
     # Add a new plot with button below it
-    def add_plot(self, title, x_axis, y_axis, offset, buffer_size, data_filepaths, datatypes, vmm_nums=None): #x_axis and y_axis are tuples of (label, unit), and buffer_size is the number of data points to display at once
+    def add_plot(self, plot_id, title, channels, x_axis, y_axis, offsets, buffer_size=10, group=None):
+        # x_axis and y_axis are tuples of (label, unit); buffer_size is the number of
+        # data points to display at once (temporary -- superseded by the time-window
+        # selector); channels is a list of channel ids registered via add_channel.
         index = self.plot_counts
         plots_per_row = self.plots_per_row
         self.plot_counts += 1
         row = index // plots_per_row
         col = index % plots_per_row
+
+        plot = Plot(
+            plot_id=plot_id, title=title, channel_ids=list(channels), x_axis=x_axis, y_axis=y_axis,
+            offsets=list(offsets), group=group, buffer_size=buffer_size,
+        )
 
         # Vertical layout to hold the plot and button
         container = QtWidgets.QVBoxLayout()
@@ -113,35 +130,27 @@ class LiveTab(QtWidgets.QWidget):
         plot_widget.setLabel('bottom', x_axis[0], units=x_axis[1])
         plot_widget.setLabel('left', y_axis[0], units=y_axis[1])
         plot_widget.showGrid(x=True, y=True)
+        plot.plot_widget = plot_widget
 
-        #Store the filepath of the data associated with this plot
-        self.data_filepaths[title] = data_filepaths
+        # Color mapping lives in a legend, not in the plot title, whenever a plot
+        # overlays more than one channel.
+        multi_curve = len(plot.channel_ids) > 1
+        if multi_curve:
+            plot_widget.addLegend()
 
-        # Store the datatype for this plot
-        self.datatype[title] = datatypes
-
-        # Store the VMM number for this plot, is None if not applicable
-        self.vmm_nums[title] = vmm_nums
-
-        num_curves = len(data_filepaths)
-        self.data[title] = []
-        self.curves[title] = []
-        COLOR_CYCLE = ['y', 'c', 'm', 'r', 'g', 'b', 'w']
-        for i in range(0, num_curves):
-            # Initialize circular buffers for x and y data
-            empty_data = {"x": pd.Series(np.full(buffer_size, np.nan), name='x'), "y": pd.Series(np.full(buffer_size, np.nan), name='y'), "offset":offset[i], "buffer_size": buffer_size}
-            self.data[title].append(empty_data)
-    
-            # Create the plot curves
+        for i, channel_id in enumerate(plot.channel_ids):
+            channel = self._channel(channel_id)
             color = COLOR_CYCLE[i % len(COLOR_CYCLE)]
-            curve = plot_widget.plot(pen=color)
-            self.curves[title].append(curve)
+            curve = plot_widget.plot(pen=color, name=channel.label if multi_curve else None)
+            plot.curves.append(curve)
+
+        self.plots[plot_id] = plot
 
         # Create the start/stop button
         start_stop_button = QtWidgets.QPushButton(f"Stop {title}")
         start_stop_button.setStyleSheet("background-color: red;")
-        start_stop_button.clicked.connect(lambda _, t=title: self.toggle_plot(t))
-        self.start_stop_buttons[title] = start_stop_button
+        start_stop_button.clicked.connect(lambda _, p=plot_id: self.toggle_plot(p))
+        plot.start_stop_button = start_stop_button
 
         # Add plot and button to vertical container
         container.addWidget(plot_widget)
@@ -150,99 +159,94 @@ class LiveTab(QtWidgets.QWidget):
         # Wrap the layout in a QWidget and add it to the grid
         container_widget = QtWidgets.QWidget()
         container_widget.setLayout(container)
-        container_widget.setMinimumSize(25*16, 40*9)
+        container_widget.setMinimumSize(25 * 16, 40 * 9)
         self.layout.addWidget(container_widget, row, col)
 
+        return plot
+
     # Update function: fetches data from file and updates the plot
-    def update(self, title):
-        num_curves = len(self.data_filepaths[title])
-        for i in range(0, num_curves):
-            x_data, y_data, offset, buffer_size = self.data[title][i]["x"], self.data[title][i]["y"], self.data[title][i]['offset'], self.data[title][i]["buffer_size"]
-            data_filepath = self.data_filepaths[title][i]
-            datatype = self.datatype[title][i]
-            if self.vmm_nums[title] is not None:
-                vmm_num = self.vmm_nums[title][i]
-            else:
-                vmm_num = None
-            
+    def update(self, plot_id):
+        plot = self.plots[plot_id]
+        for i, channel_id in enumerate(plot.channel_ids):
+            channel = self._channel(channel_id)
+            offset = plot.offsets[i]
+
             try:
-                x_data, y_data = get_n_XY_datapoints(data_filepath, buffer_size, datatype, vmm_num)
+                x_data, y_data = get_n_XY_datapoints(channel.filepath, plot.buffer_size, channel.datatype, channel.vmm_num)
             except (pd.errors.ParserError, ValueError) as e:
-                print(f"[{title}] update failed: {e}")
+                print(f"[{plot.title}] update failed: {e}")
                 continue
-            
-            self.curves[title][i].setData(x=x_data, y=y_data+float(offset))
+
+            plot.curves[i].setData(x=x_data, y=y_data + float(offset))
 
     # Return elapsed time in seconds since the plot started
-    def get_elapsed_time(self, title):
-        return self.elapsed_timers[title].elapsed() / 1000.0 #convert ms to seconds
+    def get_elapsed_time(self, plot_id):
+        return self.plots[plot_id].elapsed_timer.elapsed() / 1000.0  # convert ms to seconds
 
     # Starts the QTimer that drives the updates for a given plot
-    def start_timer(self, title, interval_ms):
+    def start_timer(self, plot_id, interval_ms):
+        plot = self.plots[plot_id]
+
         # Create a timer to update the plot regularly
         timer = QtCore.QTimer()
-        timer.timeout.connect(lambda: self.update(title))
+        timer.timeout.connect(lambda: self.update(plot_id))
         timer.start(interval_ms)
-        self.interval_timers[title] = timer
+        plot.interval_timer = timer
 
         # Start a timer to track elapsed time
         elapsed = QtCore.QElapsedTimer()
         elapsed.start()
-        self.elapsed_timers[title] = elapsed
+        plot.elapsed_timer = elapsed
 
         # Mark the plot as running
-        self.running_state[title] = True
+        plot.running = True
 
     # Toggle between start and stop for a given plot
-    def toggle_plot(self, title):
-        if self.running_state[title]:
+    def toggle_plot(self, plot_id):
+        plot = self.plots[plot_id]
+        if plot.running:
             # Stop the timer and update the button text
-            self.interval_timers[title].stop()
-            self.start_stop_buttons[title].setText(f"Start {title}")
-            self.start_stop_buttons[title].setStyleSheet("background-color: green;")
-            self.running_state[title] = False
+            plot.interval_timer.stop()
+            plot.start_stop_button.setText(f"Start {plot.title}")
+            plot.start_stop_button.setStyleSheet("background-color: green;")
+            plot.running = False
         else:
-            # Reset data and timer, restart updates
-            num_curves = len(self.data_filepaths[title])
-            for i in range(0, num_curves):
-                buffer_size = self.data[title][i]["buffer_size"]
-                offset = self.data[title][i]["offset"]
-                self.data[title][i] = {"x": pd.Series(np.full(buffer_size, np.nan), name='x'), "y": pd.Series(np.full(buffer_size, np.nan), name='y'), "offset":offset, "buffer_size": buffer_size}
-            self.elapsed_timers[title].restart()
-            self.interval_timers[title].start()
-            self.start_stop_buttons[title].setText(f"Stop {title}")
-            self.start_stop_buttons[title].setStyleSheet("background-color: red;")
-            self.running_state[title] = True
+            # Restart updates
+            plot.elapsed_timer.restart()
+            plot.interval_timer.start()
+            plot.start_stop_button.setText(f"Stop {plot.title}")
+            plot.start_stop_button.setStyleSheet("background-color: red;")
+            plot.running = True
 
-    #Run a terminal command using subprocess
+    # Run a terminal command using subprocess
     def run_terminal_command(self, title, command):
         system = platform.system()
 
         if system == 'Windows':
-            #Use shlex.split to safely split the command respecting shell syntax
+            # Use shlex.split to safely split the command respecting shell syntax
             cmd_parts = shlex.split(command, posix=False)  # Use posix=False for Windows compatibility
-            process = subprocess.Popen(cmd_parts, shell=True) #Use shell=True for Windows to handle commands correctly
+            process = subprocess.Popen(cmd_parts, shell=True)  # Use shell=True for Windows to handle commands correctly
         else:
             cmd_parts = shlex.split(command)
             process = subprocess.Popen(cmd_parts)
-        
+
         self.cmd_processes[title] = process
-    
-    #Terminate a running terminal command
+
+    # Terminate a running terminal command
     def stop_terminal_command(self, title):
         process = self.cmd_processes[title]
 
-        #Check if the process is still running and terminate it
+        # Check if the process is still running and terminate it
         if process and process.poll() is None:
             system = platform.system()
             if system == 'Windows':
                 subprocess.run(['taskkill', '/PID', str(process.pid), '/T', '/F'], check=True)
             else:
                 process.kill()
-    
-    #Handle button click for starting/stopping terminal commands
+
+    # Handle button click for starting/stopping terminal commands
     def cmd_button_clicked(self, title):
-        command = self.cmd_command_strings[title] #this method allows us to dynamically change the command if necessary
+        command = self.cmd_command_strings[title]  # this method allows us to dynamically change the command if necessary
         if self.cmd_running_state[title]:
             # If the command is running, stop it
             self.stop_terminal_command(title)
@@ -261,7 +265,7 @@ class LiveTab(QtWidgets.QWidget):
             cmd_button.setStyleSheet("background-color: red;")
 
             self.cmd_running_state[title] = True
-        
+
     # Add a button that runs a terminal command on click
     def add_command_button(self, title, command):
         index = self.plot_counts
@@ -275,7 +279,7 @@ class LiveTab(QtWidgets.QWidget):
 
         # Create button
         cmd_button = QtWidgets.QPushButton(f'Start {title}')
-        cmd_button.setStyleSheet(f"background-color: green;")
+        cmd_button.setStyleSheet("background-color: green;")
         self.cmd_command_strings[title] = command
         cmd_button.clicked.connect(lambda _, t=title: self.cmd_button_clicked(t))
         self.cmd_buttons[title] = cmd_button
@@ -290,7 +294,7 @@ class LiveTab(QtWidgets.QWidget):
 
         # Mark the command as not running
         self.cmd_running_state[title] = False
-    
+
     # Check the status of all command processes and update button states
     def check_command_status(self):
         for title in self.cmd_processes:
@@ -301,15 +305,15 @@ class LiveTab(QtWidgets.QWidget):
                 cmd_button.setText(f'Start {title}')
                 cmd_button.setStyleSheet("background-color: green;")
                 self.cmd_running_state[title] = False
-    
+
     def cmd_timer(self, interval_ms):
         # Create a timer to check command status on a regular interval
         timer = QtCore.QTimer()
         timer.timeout.connect(lambda: self.check_command_status())
         timer.start(interval_ms)
-        self.interval_timers['cmd_timer'] = timer #Store primarily to prevent garbage collection
-    
-    #Add a dropdown menu with specified options and values attached to the options
+        self.cmd_status_timer = timer  # held to prevent garbage collection
+
+    # Add a dropdown menu with specified options and values attached to the options
     def add_dropdown_menu(self, title, option_names, option_values, ctrl_var=None, on_change_callback=None):
         index = self.plot_counts
         plots_per_row = self.plots_per_row
@@ -348,15 +352,15 @@ class LiveTab(QtWidgets.QWidget):
         # Wrap the layout in a QWidget and add it to the grid
         container_widget = QtWidgets.QWidget()
         container_widget.setLayout(container)
-        container_widget.setMaximumWidth(500) #prevent stretching (aesthetics)
+        container_widget.setMaximumWidth(500)  # prevent stretching (aesthetics)
         self.layout.addWidget(container_widget, row, col)
 
-    #Changes the command string associated with a specified command button based on the title of the button
+    # Changes the command string associated with a specified command button based on the title of the button
     def change_cmd_button_command(self, title, new_command):
         self.cmd_command_strings[title] = new_command
-    
-    #Specialized function specifically for the 40L TPC commands, will likely not be useful for a general user of this program
-    #People using this program for a different use case will need to edit this function and/or write a new one to do the editing they need to the command string
+
+    # Specialized function specifically for the 40L TPC commands, will likely not be useful for a general user of this program
+    # People using this program for a different use case will need to edit this function and/or write a new one to do the editing they need to the command string
     def change_cmd(self, title, ctrl_title, dropdown_text, new_option_value):
         old_command = self.cmd_command_strings[ctrl_title]
 
@@ -365,24 +369,16 @@ class LiveTab(QtWidgets.QWidget):
 
         new_command = ' '.join(parts)
 
-        print(f'New Command: {new_command}') #for debugging
+        print(f'New Command: {new_command}')  # for debugging
 
         self.change_cmd_button_command(ctrl_title, new_command)
-    
-    #Change the buffer size of a specified plot, intended to be attached to a dropdown menu
-    def change_buffer_size(self, title, ctrl_title, dropdown_text, new_option_value):
-        num_curves = len(self.data_filepaths[ctrl_title])
-        for i in range(0, num_curves):
-            self.data[i][ctrl_title]["buffer_size"] = new_option_value
 
-    #Change the buffer size of multiple plots at once, intended to be attached to a dropdown menu
-    #ctrl_titles is a list of titles that correspond to the plots to change
-    def change_buffer_size_multiple(self, title, ctrl_titles, dropdown_text, new_option_value):
-        for i in range(len(ctrl_titles)):
-            num_curves = len(self.data_filepaths[str(ctrl_titles[i])])
-            for l in range(0, num_curves):
-                self.data[str(ctrl_titles[i])][l]["buffer_size"] = new_option_value
-    
+    # Change the buffer size of multiple plots at once, intended to be attached to a dropdown menu.
+    # ctrl_plot_ids is a list of plot_ids that correspond to the plots to change.
+    def change_buffer_size_multiple(self, title, ctrl_plot_ids, dropdown_text, new_option_value):
+        for plot_id in ctrl_plot_ids:
+            self.plots[str(plot_id)].buffer_size = new_option_value
+
     # End all running subprocesses
     def cleanup(self):
         for title in self.cmd_processes:

--- a/core_tools/gui/live_plotter_GUI_class.py
+++ b/core_tools/gui/live_plotter_GUI_class.py
@@ -198,6 +198,8 @@ class LivePlotter:
                 self._style_value_label(plot.value_labels[idx], channel, state, status, plot.offsets[idx], now)
 
         for tab in self.tab_objects.values():
+            if not isinstance(tab, LiveTab):
+                continue  # only LiveTab owns Plot objects with a border to color
             for plot in tab.plots.values():
                 any_alarm = any(self.alarm_evaluator.state_for(cid).state == AlarmState.ALARM for cid in plot.channel_ids)
                 self._set_plot_alarm_border(plot, any_alarm)
@@ -207,15 +209,13 @@ class LivePlotter:
         self._refresh_tab_badges()
         if self.overview_tab is not None:
             self.overview_tab.refresh_values(now)
+        for tab in self.tab_objects.values():
+            if isinstance(tab, VMMTab):
+                tab.refresh(now)
 
     def _refresh_tab_badges(self):
         for tab_name, tab in self.tab_objects.items():
-            alarming = set()
-            for plot in tab.plots.values():
-                for channel_id in plot.channel_ids:
-                    status = display_status(self.alarm_evaluator.state_for(channel_id))
-                    if status in (DisplayStatus.ALARM, DisplayStatus.STALE):
-                        alarming.add(channel_id)
+            alarming = tab.alarming_channel_ids(self.alarm_evaluator)
             index = self.tabs.indexOf(tab)
             if index < 0:
                 continue
@@ -276,6 +276,16 @@ class LivePlotter:
         self.tabs.addTab(tab, tab_name)
         return tab
 
+    # VMM Temperatures tab: a 4x4 tile grid (one per channel, with a checkbox) beside
+    # one overlay plot showing every checked channel's curve. threshold=None derives
+    # the single threshold line from the first channel with alarm.high configured.
+    def build_vmm_tab(self, tab_name, channel_ids, threshold=None):
+        tab = VMMTab(self, channel_ids, threshold=threshold)
+        tab.tab_name = tab_name
+        self.tab_objects[tab_name] = tab
+        self.tabs.addTab(tab, tab_name)
+        return tab
+
     # End all running logger subprocesses
     def cleanup(self):
         self._save_layout()
@@ -323,6 +333,16 @@ class LiveTab(QtWidgets.QWidget):
 
     def _channel(self, channel_id):
         return self.plotter.channels[channel_id]
+
+    # Distinct channels across this tab's plots currently in ALARM/STALE -- used for
+    # the tab-label badge (§4.6.4).
+    def alarming_channel_ids(self, evaluator):
+        result = set()
+        for plot in self.plots.values():
+            for channel_id in plot.channel_ids:
+                if display_status(evaluator.state_for(channel_id)) in (DisplayStatus.ALARM, DisplayStatus.STALE):
+                    result.add(channel_id)
+        return result
 
     @staticmethod
     def _threshold_line_values(alarm):
@@ -981,7 +1001,6 @@ class OverviewTab(QtWidgets.QWidget):
     def __init__(self, plotter):
         super().__init__()
         self.plotter = plotter
-        self.plots = {}  # always empty -- duck-types as a tab for _refresh_tab_badges()
         self.tiles = []  # [{'channel_id', 'frame', 'value_label', 'curve'}, ...]
 
         scroll = QtWidgets.QScrollArea()
@@ -1041,6 +1060,9 @@ class OverviewTab(QtWidgets.QWidget):
 
         return {'channel_id': channel.id, 'frame': frame, 'value_label': value_label, 'curve': curve}
 
+    def alarming_channel_ids(self, evaluator):
+        return set()  # Overview never gets its own badge (§4.6.4 only shows one on VMM Temperatures in the mockup)
+
     def refresh_values(self, now):
         for tile in self.tiles:
             channel = self.plotter.channels[tile['channel_id']]
@@ -1060,3 +1082,150 @@ class OverviewTab(QtWidgets.QWidget):
             except (pd.errors.ParserError, ValueError, FileNotFoundError, OSError):
                 continue
             tile['curve'].setData(x=x_data, y=y_data)
+
+
+class VMMTab(QtWidgets.QWidget):
+    '''Replaces the wall of 16 individual plots with a 4x4 tile grid (checkbox +
+    current value + alarm color) beside one overlay plot of every checked channel.'''
+
+    BUFFER_SIZE = 300  # temporary, until the time-window selector lands
+    UPDATE_INTERVAL_MS = 1000
+
+    def __init__(self, plotter, channel_ids, threshold=None):
+        super().__init__()
+        self.plotter = plotter
+        self.channel_ids = list(channel_ids)
+        self.tiles = {}   # channel_id -> {'frame', 'checkbox', 'value_label'}
+        self.curves = {}  # channel_id -> PlotDataItem
+        self._colors = {}  # channel_id -> assigned pen color, so alarm highlighting can revert to it
+
+        splitter = QtWidgets.QSplitter(QtCore.Qt.Horizontal)
+
+        left_widget = QtWidgets.QWidget()
+        left_layout = QtWidgets.QVBoxLayout()
+        left_widget.setLayout(left_layout)
+        grid = QtWidgets.QGridLayout()
+        columns = 4
+        for i, channel_id in enumerate(self.channel_ids):
+            tile = self._build_tile(channel_id)
+            grid.addWidget(tile['frame'], i // columns, i % columns)
+            self.tiles[channel_id] = tile
+        left_layout.addLayout(grid)
+        left_layout.addStretch(1)
+        splitter.addWidget(left_widget)
+
+        right_widget = QtWidgets.QWidget()
+        right_layout = QtWidgets.QVBoxLayout()
+        right_widget.setLayout(right_layout)
+
+        controls_row = QtWidgets.QHBoxLayout()
+        select_all_button = QtWidgets.QPushButton('Select All')
+        select_all_button.clicked.connect(self.select_all)
+        controls_row.addWidget(select_all_button)
+        select_none_button = QtWidgets.QPushButton('Select None')
+        select_none_button.clicked.connect(self.select_none)
+        controls_row.addWidget(select_none_button)
+        controls_row.addStretch(1)
+        right_layout.addLayout(controls_row)
+
+        self.overlay_widget = pg.PlotWidget(title='VMM Temperatures Overlay')
+        self.overlay_widget.setLabel('bottom', 'Time since present', units='s')
+        self.overlay_widget.setLabel('left', 'Temperature', units='degC')
+        self.overlay_widget.showGrid(x=True, y=True)
+        self.overlay_widget.addLegend()
+        right_layout.addWidget(self.overlay_widget)
+        splitter.addWidget(right_widget)
+        splitter.setStretchFactor(0, 1)
+        splitter.setStretchFactor(1, 2)
+
+        if threshold is None:
+            for channel_id in self.channel_ids:
+                alarm = self.plotter.channels[channel_id].alarm
+                if alarm is not None and alarm.high is not None:
+                    threshold = alarm.high
+                    break
+        if threshold is not None:
+            line = pg.InfiniteLine(pos=threshold, angle=0, pen=pg.mkPen(ALARM_COLOR, style=QtCore.Qt.DashLine))
+            self.overlay_widget.addItem(line)
+
+        for i, channel_id in enumerate(self.channel_ids):
+            channel = self.plotter.channels[channel_id]
+            color = COLOR_CYCLE[i % len(COLOR_CYCLE)]
+            self._colors[channel_id] = color
+            self.curves[channel_id] = self.overlay_widget.plot(pen=color, name=channel.label)
+
+        outer_layout = QtWidgets.QVBoxLayout()
+        outer_layout.addWidget(splitter)
+        self.setLayout(outer_layout)
+
+        self._update_timer = QtCore.QTimer()
+        self._update_timer.timeout.connect(self._update_curves)
+        self._update_timer.start(self.UPDATE_INTERVAL_MS)
+        self._update_curves()
+
+    def _build_tile(self, channel_id):
+        channel = self.plotter.channels[channel_id]
+        fec, remainder = divmod(channel.vmm_num, 8)
+        hyb, vmm = divmod(remainder, 2)
+
+        frame = QtWidgets.QFrame()
+        frame.setFrameShape(QtWidgets.QFrame.Box)
+        vbox = QtWidgets.QVBoxLayout()
+        frame.setLayout(vbox)
+
+        top_row = QtWidgets.QHBoxLayout()
+        checkbox = QtWidgets.QCheckBox()
+        checkbox.setChecked(True)
+        checkbox.stateChanged.connect(lambda state, cid=channel_id: self._on_checkbox_changed(cid, state))
+        top_row.addWidget(checkbox)
+        top_row.addWidget(QtWidgets.QLabel(f"VMM {channel.vmm_num} (F{fec}/H{hyb}/V{vmm})"))
+        vbox.addLayout(top_row)
+
+        value_label = QtWidgets.QLabel('—')
+        vbox.addWidget(value_label)
+
+        return {'frame': frame, 'checkbox': checkbox, 'value_label': value_label}
+
+    def _on_checkbox_changed(self, channel_id, state):
+        self.curves[channel_id].setVisible(state == QtCore.Qt.Checked)
+
+    def select_all(self):
+        for tile in self.tiles.values():
+            tile['checkbox'].setChecked(True)
+
+    def select_none(self):
+        for tile in self.tiles.values():
+            tile['checkbox'].setChecked(False)
+
+    def alarming_channel_ids(self, evaluator):
+        return {cid for cid in self.channel_ids if display_status(evaluator.state_for(cid)) in (DisplayStatus.ALARM, DisplayStatus.STALE)}
+
+    # Tile value/color, auto-check + curve highlight on ALARM entry. Called every
+    # alarm-scan tick, same as the status strip/overview/per-plot readouts.
+    def refresh(self, now):
+        for channel_id, tile in self.tiles.items():
+            channel = self.plotter.channels[channel_id]
+            state = self.plotter.alarm_evaluator.state_for(channel_id)
+            status = display_status(state)
+
+            text, style = format_channel_value(channel, state, status, offset=0.0, now=now)
+            tile['value_label'].setText(text)
+            tile['value_label'].setStyleSheet(style)
+            tile['frame'].setStyleSheet(f"border: 2px solid {ALARM_COLOR};" if state.state == AlarmState.ALARM else "")
+
+            curve = self.curves[channel_id]
+            if state.state == AlarmState.ALARM:
+                curve.setPen(pg.mkPen(ALARM_COLOR, width=3))
+                if not tile['checkbox'].isChecked():
+                    tile['checkbox'].setChecked(True)  # emits stateChanged -> curve becomes visible
+            else:
+                curve.setPen(pg.mkPen(self._colors[channel_id], width=1))
+
+    def _update_curves(self):
+        for channel_id in self.channel_ids:
+            channel = self.plotter.channels[channel_id]
+            try:
+                x_data, y_data = get_n_XY_datapoints(channel.filepath, self.BUFFER_SIZE, channel.datatype, channel.vmm_num)
+            except (pd.errors.ParserError, ValueError, FileNotFoundError, OSError):
+                continue
+            self.curves[channel_id].setData(x=x_data, y=y_data)

--- a/core_tools/gui/live_plotter_GUI_class.py
+++ b/core_tools/gui/live_plotter_GUI_class.py
@@ -13,6 +13,7 @@ import serial.tools.list_ports
 from .get_data_for_GUI import get_n_XY_datapoints
 from .models import Channel, Plot, LoggerControl, AggregateTile
 from .decimate import decimate_min_max
+from .data_cache import ScanRunnable
 from core_tools.alarms import AlarmEvaluator, AlarmState, DisplayStatus, display_status
 
 '''Class to handle live plotting and add various controls/buttons in a Qt GUI application.'''
@@ -132,13 +133,18 @@ class LivePlotter:
 
         self._restore_layout()
 
-        # Alarm evaluation is driven by one scanner timer here, independent of any
-        # plot's own timer/pause state (see core_tools/alarms.py and §4.4).
+        # One scan timer drives everything: alarm evaluation (independent of any
+        # plot's own pause state, see core_tools/alarms.py and §4.4) AND every plot's
+        # curve redraw. The actual file reads happen on a QThreadPool worker thread
+        # (core_tools/gui/data_cache.py) so the GUI thread never blocks on disk; a
+        # reentrancy flag drops a tick rather than queueing if the previous scan's
+        # background job hasn't finished yet.
         self.alarm_evaluator = AlarmEvaluator()
         self._alarm_last_ts = {}  # channel_id -> newest absolute timestamp already evaluated
-        self.alarm_scan_timer = QtCore.QTimer()
-        self.alarm_scan_timer.timeout.connect(self._scan_alarms)
-        self.alarm_scan_timer.start(ALARM_SCAN_INTERVAL_MS)
+        self._scan_in_flight = False
+        self.scan_timer = QtCore.QTimer()
+        self.scan_timer.timeout.connect(self._start_scan)
+        self.scan_timer.start(ALARM_SCAN_INTERVAL_MS)
 
         # Calls the cleanup function when the application is about to quit so that all running subprocesses are terminated
         self.app.aboutToQuit.connect(self.cleanup)
@@ -168,22 +174,42 @@ class LivePlotter:
         self.channels[id] = channel
         return channel
 
-    # Read every registered channel's recent rows, feed the newly-arrived ones (not
-    # just the newest) through the alarm evaluator, and refresh every plot's value
-    # readout/border from the result. Runs regardless of which plots are paused or
-    # which tab is selected.
-    def _scan_alarms(self):
-        now = time.time()
+    # Kick off one background read of every registered channel (one disk read per
+    # distinct file -- see data_cache.py), regardless of which plots are paused or
+    # which tab is selected. Dropped rather than queued if the previous scan's
+    # background job is still running.
+    def _start_scan(self):
+        if self._scan_in_flight:
+            return
+        self._scan_in_flight = True
+
+        requests = []
         for channel_id, channel in self.channels.items():
-            try:
-                times_ago, values = get_n_XY_datapoints(channel.filepath, ALARM_LOOKBACK_ROWS, channel.datatype, channel.vmm_num)
-            except (pd.errors.ParserError, ValueError, FileNotFoundError, OSError):
-                continue  # can't read right now (e.g. an external logger hasn't written yet) -- retry next tick
+            n = max(ALARM_LOOKBACK_ROWS, rows_for_window(self.window_seconds, channel.log_interval_s))
+            requests.append((channel_id, channel.filepath, n, channel.datatype, channel.vmm_num))
+
+        runnable = ScanRunnable(requests)
+        runnable.signals.finished.connect(self._on_scan_finished)
+        QtCore.QThreadPool.globalInstance().start(runnable)
+
+    # Runs on the GUI thread once the background read completes: feeds newly-arrived
+    # samples (not just the newest) through the alarm evaluator, and redraws every
+    # unpaused plot/VMM-overlay curve referencing each channel.
+    def _on_scan_finished(self, results):
+        self._scan_in_flight = False
+        now = time.time()
+
+        for channel_id, result in results.items():
+            channel = self.channels[channel_id]
+            if result[0] == 'error':
+                self.log(f"[{channel.label}] read failed: {result[1]}", level='ERROR')
+                continue
+            _, x_data, y_data = result
 
             last_seen = self._alarm_last_ts.get(channel_id)
             newest_ts = last_seen
             samples = []
-            for seconds_ago, value in zip(times_ago, values):
+            for seconds_ago, value in zip(x_data, y_data):
                 ts = now + float(seconds_ago)
                 if newest_ts is None or ts > newest_ts:
                     newest_ts = ts
@@ -197,6 +223,21 @@ class LivePlotter:
                 self.log(transition.message, level=level)
             if newest_ts is not None:
                 self._alarm_last_ts[channel_id] = newest_ts
+
+            # Decimate once per channel (independent of which plot/offset uses it)
+            # and reuse for every consumer of this channel's curve.
+            dec_x, dec_y = decimate_min_max(x_data, y_data, max_points=DECIMATION_CAP)
+
+            for tab, plot_id in self.channel_plots.get(channel_id, []):
+                plot = tab.plots.get(plot_id)
+                if plot is None or not plot.running:
+                    continue
+                idx = plot.channel_ids.index(channel_id)
+                plot.curves[idx].setData(x=dec_x, y=dec_y + float(plot.offsets[idx]))
+
+            for tab in self.tab_objects.values():
+                if isinstance(tab, VMMTab) and not tab.paused and channel_id in tab.curves:
+                    tab.curves[channel_id].setData(x=dec_x, y=dec_y)
 
         self._refresh_alarm_visuals(now)
 
@@ -308,7 +349,7 @@ class LivePlotter:
     # Show the window and start the event loop
     def run(self):
         self.main_window.show()
-        sys.exit(self.app.exec_())
+        sys.exit(self.app.exec())
 
 
 class LiveTab(QtWidgets.QWidget):
@@ -432,6 +473,7 @@ class LiveTab(QtWidgets.QWidget):
             self.plotter.channel_plots.setdefault(channel_id, []).append((self, plot_id))
 
         self.plots[plot_id] = plot
+        plot.running = True  # plots redraw by default; LivePlotter's scan tick drives all of them centrally
 
         container.addWidget(plot_widget)
 
@@ -451,61 +493,15 @@ class LiveTab(QtWidgets.QWidget):
         if plot is not None and plot.container_widget is not None:
             self.scroll_area.ensureWidgetVisible(plot.container_widget)
 
-    # Update function: fetches data from file and updates the plot
-    def update(self, plot_id):
-        plot = self.plots[plot_id]
-        for i, channel_id in enumerate(plot.channel_ids):
-            channel = self._channel(channel_id)
-            offset = plot.offsets[i]
-            n = rows_for_window(self.plotter.window_seconds, channel.log_interval_s)
-
-            try:
-                x_data, y_data = get_n_XY_datapoints(channel.filepath, n, channel.datatype, channel.vmm_num)
-            except (pd.errors.ParserError, ValueError) as e:
-                self.plotter.log(f"[{plot.title}] update failed: {e}", level='ERROR')
-                continue
-
-            x_data, y_data = decimate_min_max(x_data, y_data, max_points=DECIMATION_CAP)
-            plot.curves[i].setData(x=x_data, y=y_data + float(offset))
-
-    # Return elapsed time in seconds since the plot started
-    def get_elapsed_time(self, plot_id):
-        return self.plots[plot_id].elapsed_timer.elapsed() / 1000.0  # convert ms to seconds
-
-    # Starts the QTimer that drives the updates for a given plot
-    def start_timer(self, plot_id, interval_ms):
-        plot = self.plots[plot_id]
-
-        # Create a timer to update the plot regularly
-        timer = QtCore.QTimer()
-        timer.timeout.connect(lambda: self.update(plot_id))
-        timer.start(interval_ms)
-        plot.interval_timer = timer
-
-        # Start a timer to track elapsed time
-        elapsed = QtCore.QElapsedTimer()
-        elapsed.start()
-        plot.elapsed_timer = elapsed
-
-        # Mark the plot as running
-        plot.running = True
-
-    # Toggle between running and paused for a given plot. This only stops/starts the
-    # curve redraw -- the channel's alarm evaluation is driven entirely by
-    # LivePlotter's independent scanner timer and keeps running regardless (§4.4).
+    # Toggle between running and paused for a given plot. This is just a flag
+    # LivePlotter's scan tick checks before pushing new data into this plot's
+    # curve(s) -- the channel's alarm evaluation is driven entirely by the
+    # independent scan timer and keeps running regardless either way (§4.4).
     def toggle_plot(self, plot_id):
         plot = self.plots[plot_id]
-        if plot.running:
-            plot.interval_timer.stop()
-            plot.pause_button.setText("▶")
-            plot.pause_button.setToolTip(f"Resume {plot.title}")
-            plot.running = False
-        else:
-            plot.elapsed_timer.restart()
-            plot.interval_timer.start()
-            plot.pause_button.setText("⏸")
-            plot.pause_button.setToolTip(f"Pause {plot.title}")
-            plot.running = True
+        plot.running = not plot.running
+        plot.pause_button.setText("⏸" if plot.running else "▶")
+        plot.pause_button.setToolTip(f"{'Pause' if plot.running else 'Resume'} {plot.title}")
 
     # Register a logger's controls (LED, port, interval, start/stop) in the shared
     # control dock -- see ControlDock.add_logger_group for what this actually builds.
@@ -1108,9 +1104,9 @@ class OverviewTab(QtWidgets.QWidget):
 
 class VMMTab(QtWidgets.QWidget):
     '''Replaces the wall of 16 individual plots with a 4x4 tile grid (checkbox +
-    current value + alarm color) beside one overlay plot of every checked channel.'''
-
-    UPDATE_INTERVAL_MS = 1000
+    current value + alarm color) beside one overlay plot of every checked channel.
+    Curve data is pushed in centrally by LivePlotter._on_scan_finished(); this class
+    only owns the widgets, checkbox state, and tile styling.'''
 
     def __init__(self, plotter, channel_ids, threshold=None):
         super().__init__()
@@ -1119,6 +1115,7 @@ class VMMTab(QtWidgets.QWidget):
         self.tiles = {}   # channel_id -> {'frame', 'checkbox', 'value_label'}
         self.curves = {}  # channel_id -> PlotDataItem
         self._colors = {}  # channel_id -> assigned pen color, so alarm highlighting can revert to it
+        self.paused = False
 
         splitter = QtWidgets.QSplitter(QtCore.Qt.Horizontal)
 
@@ -1179,11 +1176,6 @@ class VMMTab(QtWidgets.QWidget):
         outer_layout.addWidget(splitter)
         self.setLayout(outer_layout)
 
-        self._update_timer = QtCore.QTimer()
-        self._update_timer.timeout.connect(self._update_curves)
-        self._update_timer.start(self.UPDATE_INTERVAL_MS)
-        self._update_curves()
-
     def _build_tile(self, channel_id):
         channel = self.plotter.channels[channel_id]
         fec, remainder = divmod(channel.vmm_num, 8)
@@ -1219,10 +1211,10 @@ class VMMTab(QtWidgets.QWidget):
             tile['checkbox'].setChecked(False)
 
     def pause(self):
-        self._update_timer.stop()
+        self.paused = True
 
     def resume(self):
-        self._update_timer.start(self.UPDATE_INTERVAL_MS)
+        self.paused = False
 
     def alarming_channel_ids(self, evaluator):
         return {cid for cid in self.channel_ids if display_status(evaluator.state_for(cid)) in (DisplayStatus.ALARM, DisplayStatus.STALE)}
@@ -1247,14 +1239,3 @@ class VMMTab(QtWidgets.QWidget):
                     tile['checkbox'].setChecked(True)  # emits stateChanged -> curve becomes visible
             else:
                 curve.setPen(pg.mkPen(self._colors[channel_id], width=1))
-
-    def _update_curves(self):
-        for channel_id in self.channel_ids:
-            channel = self.plotter.channels[channel_id]
-            n = rows_for_window(self.plotter.window_seconds, channel.log_interval_s)
-            try:
-                x_data, y_data = get_n_XY_datapoints(channel.filepath, n, channel.datatype, channel.vmm_num)
-            except (pd.errors.ParserError, ValueError, FileNotFoundError, OSError):
-                continue
-            x_data, y_data = decimate_min_max(x_data, y_data, max_points=DECIMATION_CAP)
-            self.curves[channel_id].setData(x=x_data, y=y_data)

--- a/core_tools/gui/live_plotter_GUI_class.py
+++ b/core_tools/gui/live_plotter_GUI_class.py
@@ -12,6 +12,7 @@ import serial.tools.list_ports
 
 from .get_data_for_GUI import get_n_XY_datapoints
 from .models import Channel, Plot, LoggerControl, AggregateTile
+from .decimate import decimate_min_max
 from core_tools.alarms import AlarmEvaluator, AlarmState, DisplayStatus, display_status
 
 '''Class to handle live plotting and add various controls/buttons in a Qt GUI application.'''
@@ -28,6 +29,17 @@ ALARM_COLOR = '#e74c3c'
 # shared data cache lands, which is a known, temporary duplication of file reads.
 ALARM_SCAN_INTERVAL_MS = 1000
 ALARM_LOOKBACK_ROWS = 50
+
+# Global time-window selector (§7) -- replaces the old per-tab "# data points shown"
+# dropdowns. n = ceil(window_s / channel.log_interval_s) rows are fetched per
+# channel and decimated down to DECIMATION_CAP points if that exceeds it.
+WINDOW_OPTIONS = [('1m', 60), ('5m', 300), ('15m', 900), ('1h', 3600), ('6h', 21600), ('24h', 86400)]
+DEFAULT_WINDOW_S = 300
+DECIMATION_CAP = 20000
+
+
+def rows_for_window(window_s, log_interval_s):
+    return max(2, math.ceil(window_s / log_interval_s))
 
 
 def format_channel_value(channel, state, status, offset, now):
@@ -82,6 +94,7 @@ class LivePlotter:
 
         self.settings = QtCore.QSettings('40L-TPC', 'RunControlGUI')
         self.event_log = EventLog()
+        self.window_seconds = DEFAULT_WINDOW_S  # overwritten below once ControlDock restores any saved selection
 
         # Alarm banner (hidden when nothing is active) and the status strip are
         # always visible above the tabs, regardless of which tab is selected.
@@ -326,11 +339,6 @@ class LiveTab(QtWidgets.QWidget):
 
         self.plots = {}  # plot_id -> Plot (identity/config/runtime all in one place)
 
-        # Internal state tracking for dropdown menus
-        self.dd_menus = {}
-        self.dd_option_names = {}
-        self.dd_option_values = {}
-
     def _channel(self, channel_id):
         return self.plotter.channels[channel_id]
 
@@ -362,10 +370,10 @@ class LiveTab(QtWidgets.QWidget):
     # (kept live by the alarm scanner, so it still reflects reality while the plot
     # itself is paused) plus a small pause toggle, replacing the old full-width
     # "Stop <title>" button.
-    def add_plot(self, plot_id, title, channels, x_axis, y_axis, offsets, buffer_size=10, group=None):
-        # x_axis and y_axis are tuples of (label, unit); buffer_size is the number of
-        # data points to display at once (temporary -- superseded by the time-window
-        # selector); channels is a list of channel ids registered via add_channel.
+    def add_plot(self, plot_id, title, channels, x_axis, y_axis, offsets, group=None):
+        # x_axis and y_axis are tuples of (label, unit); channels is a list of
+        # channel ids registered via add_channel. How much history is displayed is
+        # governed by the global time-window selector (§7), not a per-plot setting.
         index = self.plot_counts
         plots_per_row = self.plots_per_row
         self.plot_counts += 1
@@ -374,7 +382,7 @@ class LiveTab(QtWidgets.QWidget):
 
         plot = Plot(
             plot_id=plot_id, title=title, channel_ids=list(channels), x_axis=x_axis, y_axis=y_axis,
-            offsets=list(offsets), group=group, buffer_size=buffer_size,
+            offsets=list(offsets), group=group,
         )
 
         container = QtWidgets.QVBoxLayout()
@@ -449,13 +457,15 @@ class LiveTab(QtWidgets.QWidget):
         for i, channel_id in enumerate(plot.channel_ids):
             channel = self._channel(channel_id)
             offset = plot.offsets[i]
+            n = rows_for_window(self.plotter.window_seconds, channel.log_interval_s)
 
             try:
-                x_data, y_data = get_n_XY_datapoints(channel.filepath, plot.buffer_size, channel.datatype, channel.vmm_num)
+                x_data, y_data = get_n_XY_datapoints(channel.filepath, n, channel.datatype, channel.vmm_num)
             except (pd.errors.ParserError, ValueError) as e:
                 self.plotter.log(f"[{plot.title}] update failed: {e}", level='ERROR')
                 continue
 
+            x_data, y_data = decimate_min_max(x_data, y_data, max_points=DECIMATION_CAP)
             plot.curves[i].setData(x=x_data, y=y_data + float(offset))
 
     # Return elapsed time in seconds since the plot started
@@ -505,55 +515,6 @@ class LiveTab(QtWidgets.QWidget):
             interval_options=interval_options, default_interval=default_interval,
         )
 
-    # Add a dropdown menu with specified options and values attached to the options
-    def add_dropdown_menu(self, title, option_names, option_values, ctrl_var=None, on_change_callback=None):
-        index = self.plot_counts
-        plots_per_row = self.plots_per_row
-        self.plot_counts += 1
-        row = index // plots_per_row
-        col = index % plots_per_row
-
-        # Vertical layout to hold the plot and button
-        container = QtWidgets.QVBoxLayout()
-
-        # Label
-        label = QtWidgets.QLabel(title)
-        container.addWidget(label)
-
-        # Dropdown (QComboBox)
-        dropdown_box = QtWidgets.QComboBox()
-        for i in range(len(option_names)):
-            dropdown_box.addItem(option_names[i], userData=option_values[i])
-        self.dd_menus[title] = dropdown_box
-        self.dd_option_names[title] = option_names
-        self.dd_option_values[title] = option_values
-
-        # If a callback function is provided, connect it
-        if on_change_callback and ctrl_var:
-            dropdown_box.currentIndexChanged.connect(
-                lambda idx, t=title, ctrl_v=ctrl_var: on_change_callback(t, ctrl_v, dropdown_box.itemText(idx), dropdown_box.itemData(idx))
-            )
-        elif on_change_callback and not ctrl_var:
-            dropdown_box.currentIndexChanged.connect(
-                lambda idx, t=title: on_change_callback(t, dropdown_box.itemText(idx), dropdown_box.itemData(idx))
-            )
-
-        # Add button to vertical container
-        container.addWidget(dropdown_box)
-
-        # Wrap the layout in a QWidget and add it to the grid
-        container_widget = QtWidgets.QWidget()
-        container_widget.setLayout(container)
-        container_widget.setMaximumWidth(500)  # prevent stretching (aesthetics)
-        self.layout.addWidget(container_widget, row, col)
-
-    # Change the buffer size of multiple plots at once, intended to be attached to a dropdown menu.
-    # ctrl_plot_ids is a list of plot_ids that correspond to the plots to change.
-    def change_buffer_size_multiple(self, title, ctrl_plot_ids, dropdown_text, new_option_value):
-        for plot_id in ctrl_plot_ids:
-            self.plots[str(plot_id)].buffer_size = new_option_value
-
-
 class ControlDock(QtWidgets.QWidget):
     '''Persistent right-hand dock, visible regardless of which tab is selected. Owns
     every logger's structured subprocess lifecycle (LED, port/interval dropdowns,
@@ -574,6 +535,37 @@ class ControlDock(QtWidgets.QWidget):
 
         self.loggers_layout = QtWidgets.QVBoxLayout()
         self.layout.addLayout(self.loggers_layout)
+
+        window_row = QtWidgets.QHBoxLayout()
+        window_row.addWidget(QtWidgets.QLabel('Window:'))
+        self.window_combo = QtWidgets.QComboBox()
+        for option_label, seconds in WINDOW_OPTIONS:
+            self.window_combo.addItem(option_label, userData=seconds)
+        default_index = self.window_combo.findData(DEFAULT_WINDOW_S)
+        self.window_combo.setCurrentIndex(default_index if default_index >= 0 else 0)
+        saved_window = self.plotter.settings.value('window_seconds')
+        if saved_window is not None:
+            saved_index = self.window_combo.findData(int(saved_window))
+            if saved_index >= 0:
+                self.window_combo.setCurrentIndex(saved_index)
+        self.plotter.window_seconds = self.window_combo.currentData()
+        self.window_combo.currentIndexChanged.connect(self._on_window_changed)
+        window_row.addWidget(self.window_combo)
+        self.layout.addLayout(window_row)
+
+        pause_row = QtWidgets.QHBoxLayout()
+        pause_all_button = QtWidgets.QPushButton('Pause All')
+        pause_all_button.clicked.connect(self._pause_all)
+        pause_row.addWidget(pause_all_button)
+        resume_all_button = QtWidgets.QPushButton('Resume All')
+        resume_all_button.clicked.connect(self._resume_all)
+        pause_row.addWidget(resume_all_button)
+        self.layout.addLayout(pause_row)
+
+        acknowledge_all_button = QtWidgets.QPushButton('Acknowledge All')
+        acknowledge_all_button.clicked.connect(self._acknowledge_all)
+        self.layout.addWidget(acknowledge_all_button)
+
         self.layout.addStretch(1)
 
         self.stderr_line_received.connect(self._on_stderr_line)
@@ -587,6 +579,36 @@ class ControlDock(QtWidgets.QWidget):
 
     def _set_led(self, logger, state):
         logger.led.setStyleSheet(f"background-color: {LED_COLORS[state]}; border-radius: 6px;")
+
+    def _on_window_changed(self, idx):
+        seconds = self.window_combo.itemData(idx)
+        self.plotter.window_seconds = seconds
+        self.plotter.settings.setValue('window_seconds', seconds)
+
+    # Pauses/resumes every plot's own curve-redraw timer across every tab -- alarm
+    # evaluation is unaffected either way (§4.4), same as pausing one plot at a time.
+    def _pause_all(self):
+        for tab in self.plotter.tab_objects.values():
+            if isinstance(tab, LiveTab):
+                for plot in tab.plots.values():
+                    if plot.running:
+                        tab.toggle_plot(plot.plot_id)
+            elif isinstance(tab, VMMTab):
+                tab.pause()
+
+    def _resume_all(self):
+        for tab in self.plotter.tab_objects.values():
+            if isinstance(tab, LiveTab):
+                for plot in tab.plots.values():
+                    if not plot.running:
+                        tab.toggle_plot(plot.plot_id)
+            elif isinstance(tab, VMMTab):
+                tab.resume()
+
+    def _acknowledge_all(self):
+        for transition in self.plotter.alarm_evaluator.acknowledge_all(now=time.time()):
+            self.plotter.log(transition.message, level='INFO')
+        self.plotter.alarm_banner.refresh(time.time())
 
     # Build one logger's group box: LED, port dropdown (from the live serial port
     # list, defaulting to the declared port), interval dropdown, start/stop button,
@@ -1088,7 +1110,6 @@ class VMMTab(QtWidgets.QWidget):
     '''Replaces the wall of 16 individual plots with a 4x4 tile grid (checkbox +
     current value + alarm color) beside one overlay plot of every checked channel.'''
 
-    BUFFER_SIZE = 300  # temporary, until the time-window selector lands
     UPDATE_INTERVAL_MS = 1000
 
     def __init__(self, plotter, channel_ids, threshold=None):
@@ -1197,6 +1218,12 @@ class VMMTab(QtWidgets.QWidget):
         for tile in self.tiles.values():
             tile['checkbox'].setChecked(False)
 
+    def pause(self):
+        self._update_timer.stop()
+
+    def resume(self):
+        self._update_timer.start(self.UPDATE_INTERVAL_MS)
+
     def alarming_channel_ids(self, evaluator):
         return {cid for cid in self.channel_ids if display_status(evaluator.state_for(cid)) in (DisplayStatus.ALARM, DisplayStatus.STALE)}
 
@@ -1224,8 +1251,10 @@ class VMMTab(QtWidgets.QWidget):
     def _update_curves(self):
         for channel_id in self.channel_ids:
             channel = self.plotter.channels[channel_id]
+            n = rows_for_window(self.plotter.window_seconds, channel.log_interval_s)
             try:
-                x_data, y_data = get_n_XY_datapoints(channel.filepath, self.BUFFER_SIZE, channel.datatype, channel.vmm_num)
+                x_data, y_data = get_n_XY_datapoints(channel.filepath, n, channel.datatype, channel.vmm_num)
             except (pd.errors.ParserError, ValueError, FileNotFoundError, OSError):
                 continue
+            x_data, y_data = decimate_min_max(x_data, y_data, max_points=DECIMATION_CAP)
             self.curves[channel_id].setData(x=x_data, y=y_data)

--- a/core_tools/gui/live_plotter_GUI_class.py
+++ b/core_tools/gui/live_plotter_GUI_class.py
@@ -2,6 +2,7 @@ from pyqtgraph.Qt import QtWidgets, QtCore
 import pyqtgraph as pg
 import sys
 import time
+import datetime
 import pandas as pd
 import subprocess
 import threading
@@ -9,7 +10,7 @@ import platform
 import serial.tools.list_ports
 
 from .get_data_for_GUI import get_n_XY_datapoints
-from .models import Channel, Plot, LoggerControl
+from .models import Channel, Plot, LoggerControl, AggregateTile
 from core_tools.alarms import AlarmEvaluator, AlarmState, DisplayStatus, display_status
 
 '''Class to handle live plotting and add various controls/buttons in a Qt GUI application.'''
@@ -28,6 +29,38 @@ ALARM_SCAN_INTERVAL_MS = 1000
 ALARM_LOOKBACK_ROWS = 50
 
 
+def format_channel_value(channel, state, status, offset, now):
+    '''(text, stylesheet) for a channel's current value -- shared by per-plot value
+    readouts, status-strip tiles, and (later) the overview tab, so all three render
+    a channel's state identically.'''
+    value = state.last_value
+    if value is None or value != value:  # NaN-safe for any numeric type
+        return "—", "color: grey;"
+
+    displayed = value + offset
+    text = f"{displayed:.3g} {channel.units}"
+    if status == DisplayStatus.ALARM:
+        return text, f"color: {ALARM_COLOR}; font-weight: bold;"
+    if status == DisplayStatus.STALE:
+        age = (now - state.last_timestamp) if state.last_timestamp else 0
+        return f"{text} (stale {age:.0f}s)", "color: grey;"
+    if status == DisplayStatus.CLEARED:
+        return text, "color: #b8860b;"
+    return text, ""
+
+
+def limit_description(alarm):
+    if alarm is None:
+        return ""
+    if alarm.high is not None:
+        return f"limit {alarm.high}"
+    if alarm.abs_high is not None:
+        return f"limit ±{alarm.abs_high}"
+    if alarm.low is not None:
+        return f"limit {alarm.low}"
+    return ""
+
+
 class LivePlotter:
     def __init__(self, win_title):
         # Create the main Qt application
@@ -41,9 +74,19 @@ class LivePlotter:
         self.main_window.setCentralWidget(self.main_widget)
         self.main_window.setWindowTitle(win_title)
 
-        # Tabs (left) and the persistent control dock (right) sit side by side and stay
-        # visible regardless of which tab is selected -- same treatment as the status
-        # strip/banner/event log, which live in main_layout above/below this splitter.
+        self.tab_objects = {}  # tab_name -> LiveTab object
+        self.channels = {}     # channel_id -> Channel, registered once, shared across all tabs
+        self.channel_plots = {}  # channel_id -> [(LiveTab, plot_id), ...], for alarm-driven visuals
+
+        # Alarm banner (hidden when nothing is active) and the status strip are
+        # always visible above the tabs, regardless of which tab is selected.
+        self.alarm_banner = AlarmBanner(self)
+        self.main_layout.addWidget(self.alarm_banner)
+        self.status_strip = StatusStrip(self)
+        self.main_layout.addWidget(self.status_strip)
+
+        # Tabs (left) and the persistent control dock (right) sit side by side and
+        # also stay visible regardless of which tab is selected.
         self.tabs = QtWidgets.QTabWidget()
         self.control_dock = ControlDock(self)
 
@@ -53,10 +96,6 @@ class LivePlotter:
         self.main_splitter.setStretchFactor(0, 4)
         self.main_splitter.setStretchFactor(1, 1)
         self.main_layout.addWidget(self.main_splitter)
-
-        self.tab_objects = {}  # tab_name -> LiveTab object
-        self.channels = {}     # channel_id -> Channel, registered once, shared across all tabs
-        self.channel_plots = {}  # channel_id -> [(LiveTab, plot_id), ...], for alarm-driven visuals
 
         # Alarm evaluation is driven by one scanner timer here, independent of any
         # plot's own timer/pause state (see core_tools/alarms.py and §4.4).
@@ -123,26 +162,47 @@ class LivePlotter:
                 any_alarm = any(self.alarm_evaluator.state_for(cid).state == AlarmState.ALARM for cid in plot.channel_ids)
                 self._set_plot_alarm_border(plot, any_alarm)
 
-    def _style_value_label(self, label, channel, state, status, offset, now):
-        value = state.last_value
-        if value is None or value != value:  # NaN-safe for any numeric type (NaN != NaN)
-            label.setText(f"{channel.label}: —")
-            label.setStyleSheet("color: grey;")
-            return
+        self.status_strip.refresh(now)
+        self.alarm_banner.refresh(now)
+        self._refresh_tab_badges()
 
-        displayed = value + offset
-        text = f"{channel.label}: {displayed:.3g} {channel.units}"
-        if status == DisplayStatus.ALARM:
-            label.setStyleSheet(f"color: {ALARM_COLOR}; font-weight: bold;")
-        elif status == DisplayStatus.STALE:
-            age = (now - state.last_timestamp) if state.last_timestamp else 0
-            text += f" (stale {age:.0f}s)"
-            label.setStyleSheet("color: grey;")
-        elif status == DisplayStatus.CLEARED:
-            label.setStyleSheet("color: #b8860b;")
-        else:
-            label.setStyleSheet("")
-        label.setText(text)
+    def _refresh_tab_badges(self):
+        for tab_name, tab in self.tab_objects.items():
+            alarming = set()
+            for plot in tab.plots.values():
+                for channel_id in plot.channel_ids:
+                    status = display_status(self.alarm_evaluator.state_for(channel_id))
+                    if status in (DisplayStatus.ALARM, DisplayStatus.STALE):
+                        alarming.add(channel_id)
+            index = self.tabs.indexOf(tab)
+            if index < 0:
+                continue
+            self.tabs.setTabText(index, f"{tab_name} ●{len(alarming)}" if alarming else tab_name)
+
+    # Select the tab containing a channel's plot and scroll that plot into view --
+    # used by status-strip/overview tile clicks and the alarm banner's message.
+    def jump_to_channel(self, channel_id):
+        refs = self.channel_plots.get(channel_id, [])
+        if not refs:
+            return
+        tab, plot_id = refs[0]
+        self.tabs.setCurrentWidget(tab)
+        tab.scroll_to_plot(plot_id)
+
+    def jump_to_tab(self, tab_name):
+        tab = self.tab_objects.get(tab_name)
+        if tab is not None:
+            self.tabs.setCurrentWidget(tab)
+
+    # Declare which channels (plain channel ids or AggregateTile specs) appear in
+    # the always-visible status strip, and in what order.
+    def set_status_strip(self, tiles):
+        self.status_strip.set_tiles(tiles)
+
+    def _style_value_label(self, label, channel, state, status, offset, now):
+        text, style = format_channel_value(channel, state, status, offset, now)
+        label.setText(f"{channel.label}: {text}")
+        label.setStyleSheet(style)
 
     def _set_plot_alarm_border(self, plot, in_alarm):
         if in_alarm == plot.in_alarm_visual:
@@ -158,6 +218,7 @@ class LivePlotter:
     # Create a tab in the window to put plots and buttons in
     def create_tab(self, tab_name, plots_per_row):
         tab = LiveTab(plots_per_row, plotter=self)
+        tab.tab_name = tab_name
         self.tab_objects[tab_name] = tab
         self.tabs.addTab(tab, tab_name)
         return tab
@@ -177,10 +238,12 @@ class LiveTab(QtWidgets.QWidget):
         super().__init__()  # Call the constructor of the parent class (QWidget) to properly initialize the widget. This class is now a custom QTWidget
 
         self.plotter = plotter  # back-reference, needed to resolve channel ids
+        self.tab_name = None    # set by LivePlotter.create_tab() right after construction
 
         # Create a scroll area
         scroll = QtWidgets.QScrollArea()
         scroll.setWidgetResizable(True)
+        self.scroll_area = scroll  # kept for scroll_to_plot()
 
         # Container widget inside the scroll area
         container = QtWidgets.QWidget()
@@ -294,8 +357,16 @@ class LiveTab(QtWidgets.QWidget):
         container_widget.setLayout(container)
         container_widget.setMinimumSize(25 * 16, 40 * 9)
         self.layout.addWidget(container_widget, row, col)
+        plot.container_widget = container_widget
 
         return plot
+
+    # Scroll a specific plot into view within this tab's scroll area -- used when a
+    # status-strip tile or the alarm banner's message is clicked.
+    def scroll_to_plot(self, plot_id):
+        plot = self.plots.get(plot_id)
+        if plot is not None and plot.container_widget is not None:
+            self.scroll_area.ensureWidgetVisible(plot.container_widget)
 
     # Update function: fetches data from file and updates the plot
     def update(self, plot_id):
@@ -588,3 +659,171 @@ class ControlDock(QtWidgets.QWidget):
         for logger in self.loggers.values():
             logger.user_stopped = True
             self._kill(logger.process)
+
+
+class StatusStrip(QtWidgets.QWidget):
+    '''Fixed-height row of tiles, always visible above the tabs. Declared once via
+    LivePlotter.set_status_strip([...]) with plain channel ids and/or AggregateTile
+    specs; refreshed every alarm-scan tick.'''
+
+    def __init__(self, plotter):
+        super().__init__()
+        self.plotter = plotter
+        self.tiles = []  # [(spec, value_label), ...]
+
+        self.layout = QtWidgets.QHBoxLayout()
+        self.setLayout(self.layout)
+
+    def set_tiles(self, tile_specs):
+        while self.layout.count():
+            item = self.layout.takeAt(0)
+            if item.widget():
+                item.widget().deleteLater()
+        self.tiles = []
+
+        for spec in tile_specs:
+            frame = QtWidgets.QFrame()
+            frame.setFrameShape(QtWidgets.QFrame.Box)
+            box = QtWidgets.QVBoxLayout()
+            frame.setLayout(box)
+
+            heading = spec.label if isinstance(spec, AggregateTile) else self.plotter.channels[spec].label
+            box.addWidget(QtWidgets.QLabel(heading))
+            value_label = QtWidgets.QLabel('—')
+            box.addWidget(value_label)
+
+            frame.mousePressEvent = lambda event, s=spec: self._on_clicked(s)
+            self.layout.addWidget(frame)
+            self.tiles.append((spec, value_label))
+
+    def _on_clicked(self, spec):
+        if isinstance(spec, AggregateTile):
+            self.plotter.jump_to_tab(spec.jump_to_tab)
+        else:
+            self.plotter.jump_to_channel(spec)
+
+    def refresh(self, now):
+        for spec, value_label in self.tiles:
+            if isinstance(spec, AggregateTile):
+                self._refresh_aggregate(spec, value_label, now)
+            else:
+                self._refresh_channel(spec, value_label, now)
+
+    def _refresh_channel(self, channel_id, value_label, now):
+        channel = self.plotter.channels[channel_id]
+        state = self.plotter.alarm_evaluator.state_for(channel_id)
+        status = display_status(state)
+        text, style = format_channel_value(channel, state, status, offset=0.0, now=now)
+        value_label.setText(text)
+        value_label.setStyleSheet(style)
+
+    def _refresh_aggregate(self, spec, value_label, now):
+        worst_channel_id = None
+        worst_value = None
+        any_alarm = False
+        for channel_id in spec.channels:
+            state = self.plotter.alarm_evaluator.state_for(channel_id)
+            if display_status(state) == DisplayStatus.ALARM:
+                any_alarm = True
+            value = state.last_value
+            if value is None or value != value:
+                continue
+            if worst_value is None or (spec.reduce == 'max' and value > worst_value) or (spec.reduce == 'min' and value < worst_value):
+                worst_value = value
+                worst_channel_id = channel_id
+
+        if worst_channel_id is None:
+            value_label.setText('—')
+            value_label.setStyleSheet('color: grey;')
+            return
+
+        channel = self.plotter.channels[worst_channel_id]
+        channel_index = channel.vmm_num if channel.vmm_num is not None else worst_channel_id
+        value_label.setText(f"{worst_value:.3g} {channel.units} (ch {channel_index})")
+        value_label.setStyleSheet(f"color: {ALARM_COLOR}; font-weight: bold;" if any_alarm else "")
+
+
+class AlarmBanner(QtWidgets.QWidget):
+    '''Hidden when nothing is active. Shows the highest-priority active alarm plus a
+    count when several are active. Latched: a cleared-but-unacknowledged alarm keeps
+    the banner up (amber) until Acknowledge is clicked.'''
+
+    PRIORITY = {DisplayStatus.ALARM: 0, DisplayStatus.STALE: 1, DisplayStatus.CLEARED: 2}
+
+    def __init__(self, plotter):
+        super().__init__()
+        self.plotter = plotter
+        self._current_channel_id = None
+
+        self.layout = QtWidgets.QHBoxLayout()
+        self.setLayout(self.layout)
+
+        self.message_label = QtWidgets.QLabel('')
+        self.message_label.setStyleSheet("font-weight: bold;")
+        self.message_label.mousePressEvent = self._on_message_clicked
+        self.layout.addWidget(self.message_label, 1)
+
+        self.ack_button = QtWidgets.QPushButton('Acknowledge')
+        self.ack_button.clicked.connect(self._on_acknowledge)
+        self.layout.addWidget(self.ack_button)
+
+        self.ack_all_button = QtWidgets.QPushButton('Acknowledge All')
+        self.ack_all_button.clicked.connect(self._on_acknowledge_all)
+        self.layout.addWidget(self.ack_all_button)
+
+        self.hide()
+
+    def _active_alarms(self):
+        results = []
+        for channel_id in self.plotter.channels:
+            state = self.plotter.alarm_evaluator.state_for(channel_id)
+            status = display_status(state)
+            if status in self.PRIORITY and not state.acknowledged:
+                results.append((channel_id, status, state))
+        results.sort(key=lambda item: self.PRIORITY[item[1]])
+        return results
+
+    def refresh(self, now):
+        active = self._active_alarms()
+        if not active:
+            self._current_channel_id = None
+            self.hide()
+            return
+
+        channel_id, status, state = active[0]
+        channel = self.plotter.channels[channel_id]
+        message = self._format_message(channel, state, status, now)
+        if len(active) > 1:
+            message = f"⚠ {len(active)} alarms — {message}"
+        else:
+            message = f"⚠ {message}"
+
+        self.message_label.setText(message)
+        self._current_channel_id = channel_id
+        self.ack_all_button.setVisible(len(active) > 1)
+        self.show()
+
+    def _format_message(self, channel, state, status, now):
+        if status == DisplayStatus.ALARM:
+            limit = limit_description(channel.alarm)
+            return f"{channel.label} — {state.last_value:.3g} {channel.units} ({limit})"
+        if status == DisplayStatus.STALE:
+            age = (now - state.last_timestamp) if state.last_timestamp else 0
+            return f"{channel.label} — stale, no data for {age:.0f}s"
+        if status == DisplayStatus.CLEARED:
+            trip_str = datetime.datetime.fromtimestamp(state.trip_timestamp).strftime('%H:%M:%S') if state.trip_timestamp else '?'
+            return f"{channel.label} — cleared, peak {state.peak_value:.3g} {channel.units} at {trip_str}"
+        return channel.label
+
+    def _on_message_clicked(self, event):
+        if self._current_channel_id is not None:
+            self.plotter.jump_to_channel(self._current_channel_id)
+
+    def _on_acknowledge(self):
+        if self._current_channel_id is not None:
+            self.plotter.alarm_evaluator.acknowledge(self._current_channel_id, now=time.time())
+            self.refresh(time.time())
+
+    def _on_acknowledge_all(self):
+        self.plotter.alarm_evaluator.acknowledge_all(now=time.time())
+        self.refresh(time.time())

--- a/core_tools/gui/live_plotter_GUI_class.py
+++ b/core_tools/gui/live_plotter_GUI_class.py
@@ -2,6 +2,7 @@ from pyqtgraph.Qt import QtWidgets, QtCore
 import pyqtgraph as pg
 import sys
 import time
+import math
 import datetime
 import pandas as pd
 import subprocess
@@ -77,6 +78,7 @@ class LivePlotter:
         self.tab_objects = {}  # tab_name -> LiveTab object
         self.channels = {}     # channel_id -> Channel, registered once, shared across all tabs
         self.channel_plots = {}  # channel_id -> [(LiveTab, plot_id), ...], for alarm-driven visuals
+        self.overview_tab = None  # set by build_overview_tab(), if the caller wants one
 
         self.settings = QtCore.QSettings('40L-TPC', 'RunControlGUI')
         self.event_log = EventLog()
@@ -145,10 +147,10 @@ class LivePlotter:
 
     # Register a data source once so it can be referenced by id from any tab's plots,
     # read for the status strip, or evaluated for alarms -- with or without a plot.
-    def add_channel(self, id, label, long_label, filepath, datatype, units, log_interval_s, alarm=None, vmm_num=None):
+    def add_channel(self, id, label, long_label, filepath, datatype, units, log_interval_s, alarm=None, vmm_num=None, overview_group=None):
         channel = Channel(
             id=id, label=label, long_label=long_label, filepath=filepath, datatype=datatype,
-            units=units, log_interval_s=log_interval_s, alarm=alarm, vmm_num=vmm_num,
+            units=units, log_interval_s=log_interval_s, alarm=alarm, vmm_num=vmm_num, overview_group=overview_group,
         )
         self.channels[id] = channel
         return channel
@@ -203,6 +205,8 @@ class LivePlotter:
         self.status_strip.refresh(now)
         self.alarm_banner.refresh(now)
         self._refresh_tab_badges()
+        if self.overview_tab is not None:
+            self.overview_tab.refresh_values(now)
 
     def _refresh_tab_badges(self):
         for tab_name, tab in self.tab_objects.items():
@@ -257,6 +261,17 @@ class LivePlotter:
     def create_tab(self, tab_name, plots_per_row):
         tab = LiveTab(plots_per_row, plotter=self)
         tab.tab_name = tab_name
+        self.tab_objects[tab_name] = tab
+        self.tabs.addTab(tab, tab_name)
+        return tab
+
+    # Dashboard tab: tiles (value + sparkline) grouped by each channel's
+    # overview_group, no live plots. Call this before any other create_tab() so it
+    # lands first in tab order, and after every add_channel() call it should reflect.
+    def build_overview_tab(self, tab_name='Overview'):
+        tab = OverviewTab(self)
+        tab.tab_name = tab_name
+        self.overview_tab = tab
         self.tab_objects[tab_name] = tab
         self.tabs.addTab(tab, tab_name)
         return tab
@@ -951,3 +966,97 @@ class EventLog(QtWidgets.QWidget):
             self._file.close()
         except OSError:
             pass
+
+
+class OverviewTab(QtWidgets.QWidget):
+    '''Dashboard: tiles grouped by each channel's overview_group, no live plots.
+    Values/coloring are driven by the same alarm-scan tick as everything else (no
+    extra read); sparklines run on their own slower timer since a 5-minute trend
+    doesn't need 1s precision and re-reading every channel's history that often
+    would only add to the read duplication commit 10 exists to fix.'''
+
+    SPARKLINE_WINDOW_S = 300
+    SPARKLINE_REFRESH_MS = 5000
+
+    def __init__(self, plotter):
+        super().__init__()
+        self.plotter = plotter
+        self.plots = {}  # always empty -- duck-types as a tab for _refresh_tab_badges()
+        self.tiles = []  # [{'channel_id', 'frame', 'value_label', 'curve'}, ...]
+
+        scroll = QtWidgets.QScrollArea()
+        scroll.setWidgetResizable(True)
+        container = QtWidgets.QWidget()
+        self.layout = QtWidgets.QVBoxLayout(container)
+        scroll.setWidget(container)
+        outer_layout = QtWidgets.QVBoxLayout()
+        outer_layout.addWidget(scroll)
+        self.setLayout(outer_layout)
+
+        self._build_groups()
+
+        self._sparkline_timer = QtCore.QTimer()
+        self._sparkline_timer.timeout.connect(self.refresh_sparklines)
+        self._sparkline_timer.start(self.SPARKLINE_REFRESH_MS)
+        self.refresh_sparklines()
+
+    def _build_groups(self):
+        groups = {}
+        for channel in self.plotter.channels.values():
+            if channel.overview_group is not None:
+                groups.setdefault(channel.overview_group, []).append(channel)
+
+        for group_name, channels in groups.items():
+            box = QtWidgets.QGroupBox(group_name)
+            grid = QtWidgets.QGridLayout()
+            box.setLayout(grid)
+            columns = 4
+            for i, channel in enumerate(channels):
+                tile = self._build_tile(channel)
+                grid.addWidget(tile['frame'], i // columns, i % columns)
+                self.tiles.append(tile)
+            self.layout.addWidget(box)
+        self.layout.addStretch(1)
+
+    def _build_tile(self, channel):
+        frame = QtWidgets.QFrame()
+        frame.setFrameShape(QtWidgets.QFrame.Box)
+        vbox = QtWidgets.QVBoxLayout()
+        frame.setLayout(vbox)
+
+        vbox.addWidget(QtWidgets.QLabel(channel.label))
+        value_label = QtWidgets.QLabel('—')
+        vbox.addWidget(value_label)
+
+        sparkline = pg.PlotWidget()
+        sparkline.setFixedSize(110, 34)
+        sparkline.hideAxis('bottom')
+        sparkline.hideAxis('left')
+        sparkline.setMouseEnabled(x=False, y=False)
+        sparkline.setMenuEnabled(False)
+        curve = sparkline.plot(pen='c')
+        vbox.addWidget(sparkline)
+
+        frame.mousePressEvent = lambda event, cid=channel.id: self.plotter.jump_to_channel(cid)
+
+        return {'channel_id': channel.id, 'frame': frame, 'value_label': value_label, 'curve': curve}
+
+    def refresh_values(self, now):
+        for tile in self.tiles:
+            channel = self.plotter.channels[tile['channel_id']]
+            state = self.plotter.alarm_evaluator.state_for(tile['channel_id'])
+            status = display_status(state)
+            text, style = format_channel_value(channel, state, status, offset=0.0, now=now)
+            tile['value_label'].setText(text)
+            tile['value_label'].setStyleSheet(style)
+            tile['frame'].setStyleSheet(f"border: 2px solid {ALARM_COLOR};" if state.state == AlarmState.ALARM else "")
+
+    def refresh_sparklines(self):
+        for tile in self.tiles:
+            channel = self.plotter.channels[tile['channel_id']]
+            n = max(2, math.ceil(self.SPARKLINE_WINDOW_S / channel.log_interval_s))
+            try:
+                x_data, y_data = get_n_XY_datapoints(channel.filepath, n, channel.datatype, channel.vmm_num)
+            except (pd.errors.ParserError, ValueError, FileNotFoundError, OSError):
+                continue
+            tile['curve'].setData(x=x_data, y=y_data)

--- a/core_tools/gui/live_plotter_GUI_class.py
+++ b/core_tools/gui/live_plotter_GUI_class.py
@@ -364,9 +364,11 @@ class LiveTab(QtWidgets.QWidget):
         scroll.setWidgetResizable(True)
         self.scroll_area = scroll  # kept for scroll_to_plot()
 
-        # Container widget inside the scroll area
+        # Container widget inside the scroll area: a vertical stack of either
+        # ungrouped plots (in one flat grid) or collapsible QGroupBoxes (each with
+        # its own sub-grid), added in the order add_plot() is called (§5.3).
         container = QtWidgets.QWidget()
-        self.layout = QtWidgets.QGridLayout(container)
+        self.layout = QtWidgets.QVBoxLayout(container)
 
         scroll.setWidget(container)
 
@@ -376,7 +378,9 @@ class LiveTab(QtWidgets.QWidget):
         self.setLayout(outer_layout)
 
         self.plots_per_row = plots_per_row
-        self.plot_counts = 0
+        self._ungrouped_grid = None      # built lazily -- only if an ungrouped plot is actually added
+        self._ungrouped_count = 0
+        self._groups = {}  # group name -> {'inner': QWidget, 'grid': QGridLayout, 'count': int}
 
         self.plots = {}  # plot_id -> Plot (identity/config/runtime all in one place)
 
@@ -415,12 +419,6 @@ class LiveTab(QtWidgets.QWidget):
         # x_axis and y_axis are tuples of (label, unit); channels is a list of
         # channel ids registered via add_channel. How much history is displayed is
         # governed by the global time-window selector (§7), not a per-plot setting.
-        index = self.plot_counts
-        plots_per_row = self.plots_per_row
-        self.plot_counts += 1
-        row = index // plots_per_row
-        col = index % plots_per_row
-
         plot = Plot(
             plot_id=plot_id, title=title, channel_ids=list(channels), x_axis=x_axis, y_axis=y_axis,
             offsets=list(offsets), group=group,
@@ -477,14 +475,60 @@ class LiveTab(QtWidgets.QWidget):
 
         container.addWidget(plot_widget)
 
-        # Wrap the layout in a QWidget and add it to the grid
+        # Wrap the layout in a QWidget and place it in its group's sub-grid (or the
+        # tab's flat grid if ungrouped) -- see _grid_for_group().
         container_widget = QtWidgets.QWidget()
         container_widget.setLayout(container)
         container_widget.setMinimumSize(25 * 16, 40 * 9)
-        self.layout.addWidget(container_widget, row, col)
+        grid, index = self._grid_for_group(group)
+        row, col = index // self.plots_per_row, index % self.plots_per_row
+        grid.addWidget(container_widget, row, col)
         plot.container_widget = container_widget
 
         return plot
+
+    # Groups plots into collapsible QGroupBoxes (§5.3) stacked in the order first
+    # seen; an ungrouped plot goes into one shared flat grid instead. Returns the
+    # QGridLayout to place the next widget in, plus that grid's next free index.
+    def _grid_for_group(self, group):
+        if group is None:
+            if self._ungrouped_grid is None:
+                self._ungrouped_grid = QtWidgets.QGridLayout()
+                self.layout.addLayout(self._ungrouped_grid)
+            index = self._ungrouped_count
+            self._ungrouped_count += 1
+            return self._ungrouped_grid, index
+
+        state = self._groups.get(group)
+        if state is None:
+            box = QtWidgets.QGroupBox(group)
+            box.setCheckable(True)
+
+            settings_key = f'group_collapsed/{self.tab_name}/{group}'
+            collapsed = self.plotter.settings.value(settings_key, False, type=bool)
+            box.setChecked(not collapsed)
+
+            inner = QtWidgets.QWidget()
+            grid = QtWidgets.QGridLayout()
+            inner.setLayout(grid)
+            inner.setVisible(not collapsed)
+
+            box_layout = QtWidgets.QVBoxLayout()
+            box_layout.addWidget(inner)
+            box.setLayout(box_layout)
+
+            def on_toggled(checked, inner=inner, key=settings_key):
+                inner.setVisible(checked)
+                self.plotter.settings.setValue(key, not checked)
+            box.toggled.connect(on_toggled)
+
+            self.layout.addWidget(box)
+            state = {'grid': grid, 'count': 0}
+            self._groups[group] = state
+
+        index = state['count']
+        state['count'] += 1
+        return state['grid'], index
 
     # Scroll a specific plot into view within this tab's scroll area -- used when a
     # status-strip tile or the alarm banner's message is clicked.

--- a/core_tools/gui/live_plotter_GUI_class.py
+++ b/core_tools/gui/live_plotter_GUI_class.py
@@ -1,6 +1,7 @@
 from pyqtgraph.Qt import QtWidgets, QtCore
 import pyqtgraph as pg
 import sys
+import time
 import pandas as pd
 import subprocess
 import threading
@@ -9,12 +10,22 @@ import serial.tools.list_ports
 
 from .get_data_for_GUI import get_n_XY_datapoints
 from .models import Channel, Plot, LoggerControl
+from core_tools.alarms import AlarmEvaluator, AlarmState, DisplayStatus, display_status
 
 '''Class to handle live plotting and add various controls/buttons in a Qt GUI application.'''
 
 COLOR_CYCLE = ['y', 'c', 'm', 'r', 'g', 'b', 'w']
 
 LED_COLORS = {'running': '#2ecc71', 'stopped': '#95a5a6', 'crashed': '#e74c3c'}
+ALARM_COLOR = '#e74c3c'
+
+# How often the alarm scanner reads every registered channel and how many trailing
+# rows it fetches per read. Deliberately independent of any plot's own timer (a
+# paused plot must not pause its channels' alarm evaluation) and, for now,
+# independent of the per-plot update() reads too -- both re-read from disk until the
+# shared data cache lands, which is a known, temporary duplication of file reads.
+ALARM_SCAN_INTERVAL_MS = 1000
+ALARM_LOOKBACK_ROWS = 50
 
 
 class LivePlotter:
@@ -45,6 +56,15 @@ class LivePlotter:
 
         self.tab_objects = {}  # tab_name -> LiveTab object
         self.channels = {}     # channel_id -> Channel, registered once, shared across all tabs
+        self.channel_plots = {}  # channel_id -> [(LiveTab, plot_id), ...], for alarm-driven visuals
+
+        # Alarm evaluation is driven by one scanner timer here, independent of any
+        # plot's own timer/pause state (see core_tools/alarms.py and §4.4).
+        self.alarm_evaluator = AlarmEvaluator()
+        self._alarm_last_ts = {}  # channel_id -> newest absolute timestamp already evaluated
+        self.alarm_scan_timer = QtCore.QTimer()
+        self.alarm_scan_timer.timeout.connect(self._scan_alarms)
+        self.alarm_scan_timer.start(ALARM_SCAN_INTERVAL_MS)
 
         # Calls the cleanup function when the application is about to quit so that all running subprocesses are terminated
         self.app.aboutToQuit.connect(self.cleanup)
@@ -58,6 +78,82 @@ class LivePlotter:
         )
         self.channels[id] = channel
         return channel
+
+    # Read every registered channel's recent rows, feed the newly-arrived ones (not
+    # just the newest) through the alarm evaluator, and refresh every plot's value
+    # readout/border from the result. Runs regardless of which plots are paused or
+    # which tab is selected.
+    def _scan_alarms(self):
+        now = time.time()
+        for channel_id, channel in self.channels.items():
+            try:
+                times_ago, values = get_n_XY_datapoints(channel.filepath, ALARM_LOOKBACK_ROWS, channel.datatype, channel.vmm_num)
+            except (pd.errors.ParserError, ValueError, FileNotFoundError, OSError):
+                continue  # can't read right now (e.g. an external logger hasn't written yet) -- retry next tick
+
+            last_seen = self._alarm_last_ts.get(channel_id)
+            newest_ts = last_seen
+            samples = []
+            for seconds_ago, value in zip(times_ago, values):
+                ts = now + float(seconds_ago)
+                if newest_ts is None or ts > newest_ts:
+                    newest_ts = ts
+                if last_seen is None or ts > last_seen:
+                    samples.append((ts, float(value)))
+            samples.sort(key=lambda s: s[0])
+
+            self.alarm_evaluator.evaluate_channel(channel_id, channel.alarm, samples, now, channel.log_interval_s)
+            if newest_ts is not None:
+                self._alarm_last_ts[channel_id] = newest_ts
+
+        self._refresh_alarm_visuals(now)
+
+    def _refresh_alarm_visuals(self, now):
+        for channel_id, refs in self.channel_plots.items():
+            channel = self.channels[channel_id]
+            state = self.alarm_evaluator.state_for(channel_id)
+            status = display_status(state)
+            for tab, plot_id in refs:
+                plot = tab.plots[plot_id]
+                idx = plot.channel_ids.index(channel_id)
+                self._style_value_label(plot.value_labels[idx], channel, state, status, plot.offsets[idx], now)
+
+        for tab in self.tab_objects.values():
+            for plot in tab.plots.values():
+                any_alarm = any(self.alarm_evaluator.state_for(cid).state == AlarmState.ALARM for cid in plot.channel_ids)
+                self._set_plot_alarm_border(plot, any_alarm)
+
+    def _style_value_label(self, label, channel, state, status, offset, now):
+        value = state.last_value
+        if value is None or value != value:  # NaN-safe for any numeric type (NaN != NaN)
+            label.setText(f"{channel.label}: —")
+            label.setStyleSheet("color: grey;")
+            return
+
+        displayed = value + offset
+        text = f"{channel.label}: {displayed:.3g} {channel.units}"
+        if status == DisplayStatus.ALARM:
+            label.setStyleSheet(f"color: {ALARM_COLOR}; font-weight: bold;")
+        elif status == DisplayStatus.STALE:
+            age = (now - state.last_timestamp) if state.last_timestamp else 0
+            text += f" (stale {age:.0f}s)"
+            label.setStyleSheet("color: grey;")
+        elif status == DisplayStatus.CLEARED:
+            label.setStyleSheet("color: #b8860b;")
+        else:
+            label.setStyleSheet("")
+        label.setText(text)
+
+    def _set_plot_alarm_border(self, plot, in_alarm):
+        if in_alarm == plot.in_alarm_visual:
+            return
+        plot.in_alarm_visual = in_alarm
+        if in_alarm:
+            plot.plot_widget.setStyleSheet(f"border: 2px solid {ALARM_COLOR};")
+            plot.plot_widget.setTitle(plot.title, color=ALARM_COLOR)
+        else:
+            plot.plot_widget.setStyleSheet("")
+            plot.plot_widget.setTitle(plot.title)
 
     # Create a tab in the window to put plots and buttons in
     def create_tab(self, tab_name, plots_per_row):
@@ -110,7 +206,24 @@ class LiveTab(QtWidgets.QWidget):
     def _channel(self, channel_id):
         return self.plotter.channels[channel_id]
 
-    # Add a new plot with button below it
+    @staticmethod
+    def _threshold_line_values(alarm):
+        if alarm is None:
+            return []
+        values = []
+        if alarm.high is not None:
+            values.append(alarm.high)
+        if alarm.low is not None:
+            values.append(alarm.low)
+        if alarm.abs_high is not None:
+            values.append(alarm.abs_high)
+            values.append(-alarm.abs_high)
+        return values
+
+    # Add a new plot. Its header row carries one current-value readout per channel
+    # (kept live by the alarm scanner, so it still reflects reality while the plot
+    # itself is paused) plus a small pause toggle, replacing the old full-width
+    # "Stop <title>" button.
     def add_plot(self, plot_id, title, channels, x_axis, y_axis, offsets, buffer_size=10, group=None):
         # x_axis and y_axis are tuples of (label, unit); buffer_size is the number of
         # data points to display at once (temporary -- superseded by the time-window
@@ -126,8 +239,21 @@ class LiveTab(QtWidgets.QWidget):
             offsets=list(offsets), group=group, buffer_size=buffer_size,
         )
 
-        # Vertical layout to hold the plot and button
         container = QtWidgets.QVBoxLayout()
+
+        header_row = QtWidgets.QHBoxLayout()
+        for channel_id in plot.channel_ids:
+            value_label = QtWidgets.QLabel(f"{self._channel(channel_id).label}: —")
+            header_row.addWidget(value_label)
+            plot.value_labels.append(value_label)
+        header_row.addStretch(1)
+        pause_button = QtWidgets.QPushButton("⏸")
+        pause_button.setFixedWidth(28)
+        pause_button.setToolTip(f"Pause {title}")
+        pause_button.clicked.connect(lambda _, p=plot_id: self.toggle_plot(p))
+        plot.pause_button = pause_button
+        header_row.addWidget(pause_button)
+        container.addLayout(header_row)
 
         # Create the plot widget
         plot_widget = pg.PlotWidget(title=title)
@@ -148,17 +274,20 @@ class LiveTab(QtWidgets.QWidget):
             curve = plot_widget.plot(pen=color, name=channel.label if multi_curve else None)
             plot.curves.append(curve)
 
+            # Threshold lines are drawn offset-corrected so they still line up
+            # visually with the (offset-corrected) trace, even though alarm
+            # evaluation itself always uses the raw, un-offset value.
+            offset = plot.offsets[i]
+            for line_value in self._threshold_line_values(channel.alarm):
+                line = pg.InfiniteLine(pos=line_value + offset, angle=0, pen=pg.mkPen(ALARM_COLOR, style=QtCore.Qt.DashLine))
+                plot_widget.addItem(line)
+                plot.threshold_lines.append(line)
+
+            self.plotter.channel_plots.setdefault(channel_id, []).append((self, plot_id))
+
         self.plots[plot_id] = plot
 
-        # Create the start/stop button
-        start_stop_button = QtWidgets.QPushButton(f"Stop {title}")
-        start_stop_button.setStyleSheet("background-color: red;")
-        start_stop_button.clicked.connect(lambda _, p=plot_id: self.toggle_plot(p))
-        plot.start_stop_button = start_stop_button
-
-        # Add plot and button to vertical container
         container.addWidget(plot_widget)
-        container.addWidget(start_stop_button)
 
         # Wrap the layout in a QWidget and add it to the grid
         container_widget = QtWidgets.QWidget()
@@ -205,21 +334,21 @@ class LiveTab(QtWidgets.QWidget):
         # Mark the plot as running
         plot.running = True
 
-    # Toggle between start and stop for a given plot
+    # Toggle between running and paused for a given plot. This only stops/starts the
+    # curve redraw -- the channel's alarm evaluation is driven entirely by
+    # LivePlotter's independent scanner timer and keeps running regardless (§4.4).
     def toggle_plot(self, plot_id):
         plot = self.plots[plot_id]
         if plot.running:
-            # Stop the timer and update the button text
             plot.interval_timer.stop()
-            plot.start_stop_button.setText(f"Start {plot.title}")
-            plot.start_stop_button.setStyleSheet("background-color: green;")
+            plot.pause_button.setText("▶")
+            plot.pause_button.setToolTip(f"Resume {plot.title}")
             plot.running = False
         else:
-            # Restart updates
             plot.elapsed_timer.restart()
             plot.interval_timer.start()
-            plot.start_stop_button.setText(f"Stop {plot.title}")
-            plot.start_stop_button.setStyleSheet("background-color: red;")
+            plot.pause_button.setText("⏸")
+            plot.pause_button.setToolTip(f"Pause {plot.title}")
             plot.running = True
 
     # Register a logger's controls (LED, port, interval, start/stop) in the shared

--- a/core_tools/gui/models.py
+++ b/core_tools/gui/models.py
@@ -38,10 +38,13 @@ class Plot:
     # Runtime state, populated by LiveTab.add_plot() and mutated as the plot runs.
     plot_widget: object = None
     curves: list = field(default_factory=list)
-    start_stop_button: object = None
+    value_labels: list = field(default_factory=list)   # one per channel, in channel_ids order
+    threshold_lines: list = field(default_factory=list)
+    pause_button: object = None
     interval_timer: object = None
     elapsed_timer: object = None
     running: bool = False
+    in_alarm_visual: bool = False  # tracks current border/title styling so we only touch Qt state on change
 
 
 @dataclass

--- a/core_tools/gui/models.py
+++ b/core_tools/gui/models.py
@@ -42,3 +42,27 @@ class Plot:
     interval_timer: object = None
     elapsed_timer: object = None
     running: bool = False
+
+
+@dataclass
+class LoggerControl:
+    id: str
+    label: str
+    script: str
+    log_filepath: str
+    interval_options: list  # [(option_label, seconds), ...]
+    default_interval: float
+    port: str
+
+    # Runtime state, populated by ControlDock.add_logger_group() and mutated as it runs.
+    process: object = None
+    stderr_lines: list = field(default_factory=list)
+    running: bool = False
+    user_stopped: bool = True
+    pending_interval: float | None = None
+
+    port_combo: object = None
+    interval_combo: object = None
+    start_stop_button: object = None
+    led: object = None
+    error_label: object = None

--- a/core_tools/gui/models.py
+++ b/core_tools/gui/models.py
@@ -45,6 +45,15 @@ class Plot:
     elapsed_timer: object = None
     running: bool = False
     in_alarm_visual: bool = False  # tracks current border/title styling so we only touch Qt state on change
+    container_widget: object = None  # the grid cell's outer widget, for scroll-into-view on tile/banner click
+
+
+@dataclass
+class AggregateTile:
+    label: str
+    channels: list[str]
+    reduce: str  # 'max' or 'min'
+    jump_to_tab: str
 
 
 @dataclass

--- a/core_tools/gui/models.py
+++ b/core_tools/gui/models.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass, field
+
+from core_tools.alarms import AlarmSpec
+
+'''Declarative data model for channels and plots.
+
+A "channel" is a named data source (a file + a column/datatype to pull out of it).
+A "plot" is a visual display of one or more channels sharing a set of axes. Channels
+are registered once on the LivePlotter (so they can be read for the status strip and
+alarm evaluation even without a plot); plots reference channels by id.
+'''
+
+
+@dataclass
+class Channel:
+    id: str
+    label: str
+    long_label: str
+    filepath: str
+    datatype: str
+    units: str
+    log_interval_s: float
+    alarm: AlarmSpec | None = None
+    vmm_num: int | None = None
+
+
+@dataclass
+class Plot:
+    plot_id: str
+    title: str
+    channel_ids: list[str]
+    x_axis: tuple[str, str]
+    y_axis: tuple[str, str]
+    offsets: list[float]
+    group: str | None = None
+    buffer_size: int = 10  # TEMPORARY: superseded by the time-window selector (see §7)
+
+    # Runtime state, populated by LiveTab.add_plot() and mutated as the plot runs.
+    plot_widget: object = None
+    curves: list = field(default_factory=list)
+    start_stop_button: object = None
+    interval_timer: object = None
+    elapsed_timer: object = None
+    running: bool = False

--- a/core_tools/gui/models.py
+++ b/core_tools/gui/models.py
@@ -41,8 +41,6 @@ class Plot:
     value_labels: list = field(default_factory=list)   # one per channel, in channel_ids order
     threshold_lines: list = field(default_factory=list)
     pause_button: object = None
-    interval_timer: object = None
-    elapsed_timer: object = None
     running: bool = False
     in_alarm_visual: bool = False  # tracks current border/title styling so we only touch Qt state on change
     container_widget: object = None  # the grid cell's outer widget, for scroll-into-view on tile/banner click

--- a/core_tools/gui/models.py
+++ b/core_tools/gui/models.py
@@ -22,6 +22,7 @@ class Channel:
     log_interval_s: float
     alarm: AlarmSpec | None = None
     vmm_num: int | None = None
+    overview_group: str | None = None  # heading this channel appears under on the Overview tab; None = not shown there
 
 
 @dataclass

--- a/core_tools/gui/models.py
+++ b/core_tools/gui/models.py
@@ -34,7 +34,6 @@ class Plot:
     y_axis: tuple[str, str]
     offsets: list[float]
     group: str | None = None
-    buffer_size: int = 10  # TEMPORARY: superseded by the time-window selector (see §7)
 
     # Runtime state, populated by LiveTab.add_plot() and mutated as the plot runs.
     plot_widget: object = None

--- a/launch_GUI.py
+++ b/launch_GUI.py
@@ -25,7 +25,6 @@ filter_line_pressure_offset = 0
 filter_line_temperature_offset = 0
 filter_line_H2O_offset = 0
 
-interval_time_ms = 1000
 num_vmms = 16
 
 create_pressure_log_csv(outer_vessel_pressure_log_filepath)
@@ -74,43 +73,38 @@ plotter.build_overview_tab()
 pressure_tab = plotter.create_tab(tab_name='Gas System', plots_per_row=2)
 
 #gas system tab plots -- how much history each shows is governed by the global
-#time-window selector in the control dock (§7), not a per-plot setting
+#time-window selector in the control dock (§7), not a per-plot setting; all plots
+#redraw from LivePlotter's single scan tick, no per-plot timer to start
 outer_vessel_plot_title = 'Outer Vessel Pressure'
 pressure_tab.add_plot(plot_id='ov_pressure', title=outer_vessel_plot_title, channels=['ov_pressure_g1', 'ov_pressure_g2'],
                        x_axis=('Time since present', 's'), y_axis=('Pressure', 'Torr'),
                        offsets=[outer_vessel_pressure_g1_offset, outer_vessel_pressure_g2_offset],
                        group='Outer Vessel')
-pressure_tab.start_timer(plot_id='ov_pressure', interval_ms=interval_time_ms)
 
 gauge_pressure_plot_title = 'Gauge Pressure'
 pressure_tab.add_plot(plot_id='gauge_pressure', title=gauge_pressure_plot_title, channels=['gauge_pressure'],
                        x_axis=('Time since present', 's'), y_axis=('Pressure', 'Torr'),
                        offsets=[gauge_pressure_offset], group='Outer Vessel')
-pressure_tab.start_timer(plot_id='gauge_pressure', interval_ms=interval_time_ms)
 
 filter_line_gas_flow_plot_title = 'Filter Line Gas Flowrate'
 pressure_tab.add_plot(plot_id='filter_line_flow', title=filter_line_gas_flow_plot_title, channels=['filter_line_flow'],
                        x_axis=('Time since present', 's'), y_axis=('Flowrate', 'SLM'),
                        offsets=[filter_line_gas_flow_offset], group='Filter Line')
-pressure_tab.start_timer(plot_id='filter_line_flow', interval_ms=interval_time_ms)
 
 filter_line_pressure_plot_title = 'Filter Line Pressure'
 pressure_tab.add_plot(plot_id='filter_line_pressure', title=filter_line_pressure_plot_title, channels=['filter_line_pressure'],
                        x_axis=('Time since present', 's'), y_axis=('Pressure', 'Torr'),
                        offsets=[filter_line_pressure_offset], group='Filter Line')
-pressure_tab.start_timer(plot_id='filter_line_pressure', interval_ms=interval_time_ms)
 
 filter_line_temperature_plot_title = 'Filter Line Temperature'
 pressure_tab.add_plot(plot_id='filter_line_temperature', title=filter_line_temperature_plot_title, channels=['filter_line_temperature'],
                        x_axis=('Time since present', 's'), y_axis=('Temperature', 'degC'),
                        offsets=[filter_line_temperature_offset], group='Filter Line')
-pressure_tab.start_timer(plot_id='filter_line_temperature', interval_ms=interval_time_ms)
 
 filter_line_H2O_plot_title = 'Filter Line H2O Concentration'
 pressure_tab.add_plot(plot_id='filter_line_h2o', title=filter_line_H2O_plot_title, channels=['filter_line_h2o'],
                        x_axis=('Time since present', 's'), y_axis=('Concentration', 'ppm'),
                        offsets=[filter_line_H2O_offset], group='Filter Line')
-pressure_tab.start_timer(plot_id='filter_line_h2o', interval_ms=interval_time_ms)
 
 #pressure tab controls
 log_interval_options = [('2s', 2), ('10s', 10), ('1m', 60), ('10m', 600), ('1hr', 3600)]

--- a/launch_GUI.py
+++ b/launch_GUI.py
@@ -36,32 +36,40 @@ create_H2O_log_csv(vaisala_H2O_log_filepath)
 Alarm thresholds live here; see core_tools/alarms.py for what each AlarmSpec field means.'''
 plotter.add_channel(id='ov_pressure_g1', label='OV g1', long_label='Outer Vessel Gauge 1 Pressure',
                      filepath=outer_vessel_pressure_log_filepath, datatype='outer_vessel_gauge_1_pressure',
-                     units='Torr', log_interval_s=2, alarm=AlarmSpec(high=760.0, clear_high=750.0))
+                     units='Torr', log_interval_s=2, alarm=AlarmSpec(high=760.0, clear_high=750.0),
+                     overview_group='Outer Vessel')
 plotter.add_channel(id='ov_pressure_g2', label='OV g2', long_label='Outer Vessel Gauge 2 Pressure',
                      filepath=outer_vessel_pressure_log_filepath, datatype='outer_vessel_gauge_2_pressure',
-                     units='Torr', log_interval_s=2, alarm=AlarmSpec(high=760.0, clear_high=750.0))
+                     units='Torr', log_interval_s=2, alarm=AlarmSpec(high=760.0, clear_high=750.0),
+                     overview_group='Outer Vessel')
 #The gauge pressure sensor is +/-5V mapped to +/-5 Torr, so a *saturated* sensor reads exactly
 #5.00 and will not trip a strict `> 5.0` test. This limit intentionally detects impossible
 #readings (a wiring/scaling fault), not saturation -- do not change the comparison to `>=`.
 plotter.add_channel(id='gauge_pressure', label='Gauge', long_label='Gauge Pressure',
                      filepath=gauge_pressure_log_filepath, datatype='gauge_pressure',
-                     units='Torr', log_interval_s=0.5, alarm=AlarmSpec(abs_high=5.0, clear_abs_high=4.5))
+                     units='Torr', log_interval_s=0.5, alarm=AlarmSpec(abs_high=5.0, clear_abs_high=4.5),
+                     overview_group='Outer Vessel')
 plotter.add_channel(id='filter_line_flow', label='Flow', long_label='Filter Line Gas Flowrate',
                      filepath=alicat_flow_pressure_temp_log_filepath, datatype='filter_line_flowrate',
-                     units='SLM', log_interval_s=1)
+                     units='SLM', log_interval_s=1, overview_group='Filter Line')
 plotter.add_channel(id='filter_line_pressure', label='FL Press', long_label='Filter Line Pressure',
                      filepath=alicat_flow_pressure_temp_log_filepath, datatype='filter_line_pressure',
-                     units='Torr', log_interval_s=1)
+                     units='Torr', log_interval_s=1, overview_group='Filter Line')
 plotter.add_channel(id='filter_line_temperature', label='FL Temp', long_label='Filter Line Temperature',
                      filepath=alicat_flow_pressure_temp_log_filepath, datatype='filter_line_temperature',
-                     units='degC', log_interval_s=1)
+                     units='degC', log_interval_s=1, overview_group='Filter Line')
 plotter.add_channel(id='filter_line_h2o', label='H2O', long_label='Filter Line H2O Concentration',
                      filepath=vaisala_H2O_log_filepath, datatype='filter_line_H2O_concentration',
-                     units='ppm', log_interval_s=2)
+                     units='ppm', log_interval_s=2, overview_group='Filter Line')
 for i in range(num_vmms):
     plotter.add_channel(id=f'vmm_temp_{i}', label=f'VMM {i}', long_label=f'VMM {i} Temperature',
                          filepath=vmm_temperatures_log_filepath, datatype='vmm_temperature',
-                         units='degC', log_interval_s=2, alarm=AlarmSpec(high=40.0, clear_high=38.0), vmm_num=i)
+                         units='degC', log_interval_s=2, alarm=AlarmSpec(high=40.0, clear_high=38.0), vmm_num=i,
+                         overview_group='VMM Temperatures')
+
+'''OVERVIEW TAB -- built first so it lands first in tab order; reflects every
+channel registered above via each one's overview_group.'''
+plotter.build_overview_tab()
 
 '''GAS SYSTEM TAB'''
 pressure_tab = plotter.create_tab(tab_name='Gas System', plots_per_row=2)

--- a/launch_GUI.py
+++ b/launch_GUI.py
@@ -24,7 +24,6 @@ filter_line_gas_flow_offset = 0
 filter_line_pressure_offset = 0
 filter_line_temperature_offset = 0
 filter_line_H2O_offset = 0
-vmm_temperatures_offset = 0
 
 interval_time_ms = 1000
 num_vmms = 16
@@ -125,19 +124,9 @@ pressure_tab.add_logger_control(id='log_h2o', label='H2O Concentration', script=
 
 pressure_tab.add_dropdown_menu(title='# data points shown', option_names=['10', '50', '100', '1000', '10000', '100000'], option_values=[10, 50, 100, 1000, 10000, 100000], ctrl_var=pressure_ctrl_plot_ids, on_change_callback=pressure_tab.change_buffer_size_multiple)
 
-'''VMM TEMPERATURES TAB'''
-temp_tab = plotter.create_tab(tab_name='VMM Temperatures', plots_per_row=4)
-
-#VMM temperature tab plots
-vmm_plot_ids = []
-for i in range(num_vmms):
-    plot_id = f'vmm_temp_{i}'
-    temp_tab.add_plot(plot_id=plot_id, title=f'VMM {i} Temperature', channels=[plot_id],
-                       x_axis=('Time since present', 's'), y_axis=('Temperature', 'degC'),
-                       offsets=[vmm_temperatures_offset], buffer_size=10)
-    temp_tab.start_timer(plot_id=plot_id, interval_ms=interval_time_ms)
-    vmm_plot_ids.append(plot_id)
-temp_tab.add_dropdown_menu(title='# data points shown', option_names=['10', '50', '100', '1000', '10000'], option_values=[10, 50, 100, 1000, 10000], ctrl_var=vmm_plot_ids, on_change_callback=temp_tab.change_buffer_size_multiple)
+'''VMM TEMPERATURES TAB -- tile grid + one overlay plot (§5.4), not 16 separate plots'''
+vmm_plot_ids = [f'vmm_temp_{i}' for i in range(num_vmms)]
+temp_tab = plotter.build_vmm_tab('VMM Temperatures', vmm_plot_ids)
 
 '''STATUS STRIP -- always visible above the tabs, regardless of which one is selected'''
 plotter.set_status_strip([

--- a/launch_GUI.py
+++ b/launch_GUI.py
@@ -73,47 +73,46 @@ plotter.build_overview_tab()
 '''GAS SYSTEM TAB'''
 pressure_tab = plotter.create_tab(tab_name='Gas System', plots_per_row=2)
 
-#gas system tab plots
+#gas system tab plots -- how much history each shows is governed by the global
+#time-window selector in the control dock (§7), not a per-plot setting
 outer_vessel_plot_title = 'Outer Vessel Pressure'
 pressure_tab.add_plot(plot_id='ov_pressure', title=outer_vessel_plot_title, channels=['ov_pressure_g1', 'ov_pressure_g2'],
                        x_axis=('Time since present', 's'), y_axis=('Pressure', 'Torr'),
                        offsets=[outer_vessel_pressure_g1_offset, outer_vessel_pressure_g2_offset],
-                       buffer_size=10, group='Outer Vessel')
+                       group='Outer Vessel')
 pressure_tab.start_timer(plot_id='ov_pressure', interval_ms=interval_time_ms)
 
 gauge_pressure_plot_title = 'Gauge Pressure'
 pressure_tab.add_plot(plot_id='gauge_pressure', title=gauge_pressure_plot_title, channels=['gauge_pressure'],
                        x_axis=('Time since present', 's'), y_axis=('Pressure', 'Torr'),
-                       offsets=[gauge_pressure_offset], buffer_size=10, group='Outer Vessel')
+                       offsets=[gauge_pressure_offset], group='Outer Vessel')
 pressure_tab.start_timer(plot_id='gauge_pressure', interval_ms=interval_time_ms)
 
 filter_line_gas_flow_plot_title = 'Filter Line Gas Flowrate'
 pressure_tab.add_plot(plot_id='filter_line_flow', title=filter_line_gas_flow_plot_title, channels=['filter_line_flow'],
                        x_axis=('Time since present', 's'), y_axis=('Flowrate', 'SLM'),
-                       offsets=[filter_line_gas_flow_offset], buffer_size=10, group='Filter Line')
+                       offsets=[filter_line_gas_flow_offset], group='Filter Line')
 pressure_tab.start_timer(plot_id='filter_line_flow', interval_ms=interval_time_ms)
 
 filter_line_pressure_plot_title = 'Filter Line Pressure'
 pressure_tab.add_plot(plot_id='filter_line_pressure', title=filter_line_pressure_plot_title, channels=['filter_line_pressure'],
                        x_axis=('Time since present', 's'), y_axis=('Pressure', 'Torr'),
-                       offsets=[filter_line_pressure_offset], buffer_size=10, group='Filter Line')
+                       offsets=[filter_line_pressure_offset], group='Filter Line')
 pressure_tab.start_timer(plot_id='filter_line_pressure', interval_ms=interval_time_ms)
 
 filter_line_temperature_plot_title = 'Filter Line Temperature'
 pressure_tab.add_plot(plot_id='filter_line_temperature', title=filter_line_temperature_plot_title, channels=['filter_line_temperature'],
                        x_axis=('Time since present', 's'), y_axis=('Temperature', 'degC'),
-                       offsets=[filter_line_temperature_offset], buffer_size=10, group='Filter Line')
+                       offsets=[filter_line_temperature_offset], group='Filter Line')
 pressure_tab.start_timer(plot_id='filter_line_temperature', interval_ms=interval_time_ms)
 
 filter_line_H2O_plot_title = 'Filter Line H2O Concentration'
 pressure_tab.add_plot(plot_id='filter_line_h2o', title=filter_line_H2O_plot_title, channels=['filter_line_h2o'],
                        x_axis=('Time since present', 's'), y_axis=('Concentration', 'ppm'),
-                       offsets=[filter_line_H2O_offset], buffer_size=10, group='Filter Line')
+                       offsets=[filter_line_H2O_offset], group='Filter Line')
 pressure_tab.start_timer(plot_id='filter_line_h2o', interval_ms=interval_time_ms)
 
 #pressure tab controls
-pressure_ctrl_plot_ids = ['ov_pressure', 'gauge_pressure', 'filter_line_flow', 'filter_line_pressure', 'filter_line_temperature', 'filter_line_h2o']
-
 log_interval_options = [('2s', 2), ('10s', 10), ('1m', 60), ('10m', 600), ('1hr', 3600)]
 pressure_tab.add_logger_control(id='log_ov_pressure', label='OV Pressure', script='log_pressure.py',
                                  log_filepath=outer_vessel_pressure_log_filepath, port='COM3',
@@ -121,8 +120,6 @@ pressure_tab.add_logger_control(id='log_ov_pressure', label='OV Pressure', scrip
 pressure_tab.add_logger_control(id='log_h2o', label='H2O Concentration', script='log_H2O_readings.py',
                                  log_filepath=vaisala_H2O_log_filepath, port='COM7',
                                  interval_options=log_interval_options, default_interval=2)
-
-pressure_tab.add_dropdown_menu(title='# data points shown', option_names=['10', '50', '100', '1000', '10000', '100000'], option_values=[10, 50, 100, 1000, 10000, 100000], ctrl_var=pressure_ctrl_plot_ids, on_change_callback=pressure_tab.change_buffer_size_multiple)
 
 '''VMM TEMPERATURES TAB -- tile grid + one overlay plot (§5.4), not 16 separate plots'''
 vmm_plot_ids = [f'vmm_temp_{i}' for i in range(num_vmms)]

--- a/launch_GUI.py
+++ b/launch_GUI.py
@@ -1,9 +1,10 @@
 from core_tools.gui.live_plotter_GUI_class import LivePlotter
 from core_tools.MKSPDR2000_pressure.save_pressure_readings_functions import create_pressure_log_csv
 from core_tools.VaisalaDMT143_H2Osensor.save_H2O_sensor_readings_functions import create_H2O_log_csv
+from core_tools.alarms import AlarmSpec
 
 '''Launches run control GUI for the 40L system as specified by the user in this file.'''
-#Create the files for logging data BEFORE adding the relevant plot to the GUI window because the plotter will look for the file when it is created. Use the create_X_log_csv functions to create the files.
+#Create the files for logging data BEFORE registering the relevant channel because the plotter will look for the file when the channel is registered. Use the create_X_log_csv functions to create the files.
 #Do NOT use any filenames with whitespaces in them, as this will cause issues with the terminal command buttons.
 #The widgets (plots, buttons, etc.) are added to the GUI window in the order they are written here and fill from left to right, top to bottom.
 #For more infromation on how to use the LivePlotter class, see source code at core_tools/gui/live_plotter_GUI_class.py
@@ -26,47 +27,93 @@ filter_line_H2O_offset = 0
 vmm_temperatures_offset = 0
 
 interval_time_ms = 1000
+num_vmms = 16
 
-'''GAS SYSTEM TAB'''
 create_pressure_log_csv(outer_vessel_pressure_log_filepath)
 create_H2O_log_csv(vaisala_H2O_log_filepath)
+
+'''CHANNELS -- each data source is declared once, independent of which plot (if any) displays it.
+Alarm thresholds live here; see core_tools/alarms.py for what each AlarmSpec field means.'''
+plotter.add_channel(id='ov_pressure_g1', label='OV g1', long_label='Outer Vessel Gauge 1 Pressure',
+                     filepath=outer_vessel_pressure_log_filepath, datatype='outer_vessel_gauge_1_pressure',
+                     units='Torr', log_interval_s=2, alarm=AlarmSpec(high=760.0, clear_high=750.0))
+plotter.add_channel(id='ov_pressure_g2', label='OV g2', long_label='Outer Vessel Gauge 2 Pressure',
+                     filepath=outer_vessel_pressure_log_filepath, datatype='outer_vessel_gauge_2_pressure',
+                     units='Torr', log_interval_s=2, alarm=AlarmSpec(high=760.0, clear_high=750.0))
+#The gauge pressure sensor is +/-5V mapped to +/-5 Torr, so a *saturated* sensor reads exactly
+#5.00 and will not trip a strict `> 5.0` test. This limit intentionally detects impossible
+#readings (a wiring/scaling fault), not saturation -- do not change the comparison to `>=`.
+plotter.add_channel(id='gauge_pressure', label='Gauge', long_label='Gauge Pressure',
+                     filepath=gauge_pressure_log_filepath, datatype='gauge_pressure',
+                     units='Torr', log_interval_s=0.5, alarm=AlarmSpec(abs_high=5.0, clear_abs_high=4.5))
+plotter.add_channel(id='filter_line_flow', label='Flow', long_label='Filter Line Gas Flowrate',
+                     filepath=alicat_flow_pressure_temp_log_filepath, datatype='filter_line_flowrate',
+                     units='SLM', log_interval_s=1)
+plotter.add_channel(id='filter_line_pressure', label='FL Press', long_label='Filter Line Pressure',
+                     filepath=alicat_flow_pressure_temp_log_filepath, datatype='filter_line_pressure',
+                     units='Torr', log_interval_s=1)
+plotter.add_channel(id='filter_line_temperature', label='FL Temp', long_label='Filter Line Temperature',
+                     filepath=alicat_flow_pressure_temp_log_filepath, datatype='filter_line_temperature',
+                     units='degC', log_interval_s=1)
+plotter.add_channel(id='filter_line_h2o', label='H2O', long_label='Filter Line H2O Concentration',
+                     filepath=vaisala_H2O_log_filepath, datatype='filter_line_H2O_concentration',
+                     units='ppm', log_interval_s=2)
+for i in range(num_vmms):
+    plotter.add_channel(id=f'vmm_temp_{i}', label=f'VMM {i}', long_label=f'VMM {i} Temperature',
+                         filepath=vmm_temperatures_log_filepath, datatype='vmm_temperature',
+                         units='degC', log_interval_s=2, alarm=AlarmSpec(high=40.0, clear_high=38.0), vmm_num=i)
+
+'''GAS SYSTEM TAB'''
 pressure_tab = plotter.create_tab(tab_name='Gas System', plots_per_row=2)
 
 #gas system tab plots
-outer_vessel_plot_title = 'Outer Vessel Pressure (g1=yellow & g2=cyan)'
-pressure_tab.add_plot(title=outer_vessel_plot_title, x_axis=('Time since present', 's'), y_axis=('Pressure', 'Torr'), offset=[outer_vessel_pressure_g1_offset, outer_vessel_pressure_g2_offset], buffer_size=10, data_filepaths=[outer_vessel_pressure_log_filepath, outer_vessel_pressure_log_filepath], datatypes=['outer_vessel_gauge_1_pressure', 'outer_vessel_gauge_2_pressure'])
-pressure_tab.start_timer(title=outer_vessel_plot_title, interval_ms=interval_time_ms)
+outer_vessel_plot_title = 'Outer Vessel Pressure'
+pressure_tab.add_plot(plot_id='ov_pressure', title=outer_vessel_plot_title, channels=['ov_pressure_g1', 'ov_pressure_g2'],
+                       x_axis=('Time since present', 's'), y_axis=('Pressure', 'Torr'),
+                       offsets=[outer_vessel_pressure_g1_offset, outer_vessel_pressure_g2_offset],
+                       buffer_size=10, group='Outer Vessel')
+pressure_tab.start_timer(plot_id='ov_pressure', interval_ms=interval_time_ms)
 
 gauge_pressure_plot_title = 'Gauge Pressure'
-pressure_tab.add_plot(title=gauge_pressure_plot_title, x_axis=('Time since present', 's'), y_axis=('Pressure', 'Torr'), offset=[gauge_pressure_offset], buffer_size=10, data_filepaths=[gauge_pressure_log_filepath], datatypes=['gauge_pressure'])
-pressure_tab.start_timer(title=gauge_pressure_plot_title, interval_ms=interval_time_ms)
+pressure_tab.add_plot(plot_id='gauge_pressure', title=gauge_pressure_plot_title, channels=['gauge_pressure'],
+                       x_axis=('Time since present', 's'), y_axis=('Pressure', 'Torr'),
+                       offsets=[gauge_pressure_offset], buffer_size=10, group='Outer Vessel')
+pressure_tab.start_timer(plot_id='gauge_pressure', interval_ms=interval_time_ms)
 
 filter_line_gas_flow_plot_title = 'Filter Line Gas Flowrate'
-pressure_tab.add_plot(title=filter_line_gas_flow_plot_title, x_axis=('Time since present', 's'), y_axis=('Flowrate', 'SL/min'), offset=[filter_line_gas_flow_offset], buffer_size=10, data_filepaths=[alicat_flow_pressure_temp_log_filepath], datatypes=['filter_line_flowrate'])
-pressure_tab.start_timer(title=filter_line_gas_flow_plot_title, interval_ms=interval_time_ms)
+pressure_tab.add_plot(plot_id='filter_line_flow', title=filter_line_gas_flow_plot_title, channels=['filter_line_flow'],
+                       x_axis=('Time since present', 's'), y_axis=('Flowrate', 'SLM'),
+                       offsets=[filter_line_gas_flow_offset], buffer_size=10, group='Filter Line')
+pressure_tab.start_timer(plot_id='filter_line_flow', interval_ms=interval_time_ms)
 
 filter_line_pressure_plot_title = 'Filter Line Pressure'
-pressure_tab.add_plot(title=filter_line_pressure_plot_title, x_axis=('Time since present', 's'), y_axis=('Pressure', 'Torr'), offset=[filter_line_pressure_offset], buffer_size=10, data_filepaths=[alicat_flow_pressure_temp_log_filepath], datatypes=['filter_line_pressure'])
-pressure_tab.start_timer(title=filter_line_pressure_plot_title, interval_ms=interval_time_ms)
+pressure_tab.add_plot(plot_id='filter_line_pressure', title=filter_line_pressure_plot_title, channels=['filter_line_pressure'],
+                       x_axis=('Time since present', 's'), y_axis=('Pressure', 'Torr'),
+                       offsets=[filter_line_pressure_offset], buffer_size=10, group='Filter Line')
+pressure_tab.start_timer(plot_id='filter_line_pressure', interval_ms=interval_time_ms)
 
 filter_line_temperature_plot_title = 'Filter Line Temperature'
-pressure_tab.add_plot(title=filter_line_temperature_plot_title, x_axis=('Time since present', 's'), y_axis=('Temperature', 'deg C'), offset=[filter_line_temperature_offset], buffer_size=10, data_filepaths=[alicat_flow_pressure_temp_log_filepath], datatypes=['filter_line_temperature'])
-pressure_tab.start_timer(title=filter_line_temperature_plot_title, interval_ms=interval_time_ms)
+pressure_tab.add_plot(plot_id='filter_line_temperature', title=filter_line_temperature_plot_title, channels=['filter_line_temperature'],
+                       x_axis=('Time since present', 's'), y_axis=('Temperature', 'degC'),
+                       offsets=[filter_line_temperature_offset], buffer_size=10, group='Filter Line')
+pressure_tab.start_timer(plot_id='filter_line_temperature', interval_ms=interval_time_ms)
 
 filter_line_H2O_plot_title = 'Filter Line H2O Concentration'
-pressure_tab.add_plot(title=filter_line_H2O_plot_title, x_axis=('Time since present', 's'), y_axis=('Concentration', 'ppm_v'), offset=[filter_line_H2O_offset], buffer_size=10, data_filepaths=[vaisala_H2O_log_filepath], datatypes=['filter_line_H2O_concentration'])
-pressure_tab.start_timer(title=filter_line_H2O_plot_title, interval_ms=interval_time_ms)
+pressure_tab.add_plot(plot_id='filter_line_h2o', title=filter_line_H2O_plot_title, channels=['filter_line_h2o'],
+                       x_axis=('Time since present', 's'), y_axis=('Concentration', 'ppm'),
+                       offsets=[filter_line_H2O_offset], buffer_size=10, group='Filter Line')
+pressure_tab.start_timer(plot_id='filter_line_h2o', interval_ms=interval_time_ms)
 
 #pressure tab controls
-pressure_ctrl_titles = [outer_vessel_plot_title, gauge_pressure_plot_title, filter_line_gas_flow_plot_title, filter_line_pressure_plot_title, filter_line_temperature_plot_title, filter_line_H2O_plot_title]
+pressure_ctrl_plot_ids = ['ov_pressure', 'gauge_pressure', 'filter_line_flow', 'filter_line_pressure', 'filter_line_temperature', 'filter_line_h2o']
 
-pressure_tab.add_dropdown_menu(title='Pressure log increment', option_names=['2s', '10s', '1m', '10m', '1hr'], option_values=[2, 10, 60, 600, 600*6], ctrl_var='Log Outer Vessel Pressure', on_change_callback=pressure_tab.change_cmd)
-pressure_tab.add_dropdown_menu(title='H2O concentration log increment', option_names=['2s', '10s', '1m', '10m', '1hr'], option_values=[2, 10, 60, 600, 600*6], ctrl_var='Log H2O Concentration', on_change_callback=pressure_tab.change_cmd)
+pressure_tab.add_dropdown_menu(title='Pressure log increment', option_names=['2s', '10s', '1m', '10m', '1hr'], option_values=[2, 10, 60, 600, 3600], ctrl_var='Log Outer Vessel Pressure', on_change_callback=pressure_tab.change_cmd)
+pressure_tab.add_dropdown_menu(title='H2O concentration log increment', option_names=['2s', '10s', '1m', '10m', '1hr'], option_values=[2, 10, 60, 600, 3600], ctrl_var='Log H2O Concentration', on_change_callback=pressure_tab.change_cmd)
 
 pressure_tab.add_command_button(title='Log Outer Vessel Pressure', command=f'python log_pressure.py {outer_vessel_pressure_log_filepath} COM3 2')
 pressure_tab.add_command_button(title='Log H2O Concentration', command=f'python log_H2O_readings.py {vaisala_H2O_log_filepath} COM7 2')
 
-pressure_tab.add_dropdown_menu(title='# data points shown', option_names=['10', '50', '100', '1000', '10000', '100000'], option_values=[10, 50, 100, 1000, 10000, 100000], ctrl_var=pressure_ctrl_titles, on_change_callback=pressure_tab.change_buffer_size_multiple)
+pressure_tab.add_dropdown_menu(title='# data points shown', option_names=['10', '50', '100', '1000', '10000', '100000'], option_values=[10, 50, 100, 1000, 10000, 100000], ctrl_var=pressure_ctrl_plot_ids, on_change_callback=pressure_tab.change_buffer_size_multiple)
 
 pressure_tab.cmd_timer(100)
 
@@ -74,12 +121,14 @@ pressure_tab.cmd_timer(100)
 temp_tab = plotter.create_tab(tab_name='VMM Temperatures', plots_per_row=4)
 
 #VMM temperature tab plots
-num_vmms = 16
-temp_ctrl_titles = []
-for i in range(0, num_vmms):
-    temp_tab.add_plot(title=f'VMM {i} Temperature', x_axis=('Time since present', 's'), y_axis=('Temperature', 'deg C'), offset=[vmm_temperatures_offset], buffer_size=10, data_filepaths=[vmm_temperatures_log_filepath], datatypes=['vmm_temperature'], vmm_nums=[i])
-    temp_tab.start_timer(title=f'VMM {i} Temperature', interval_ms=interval_time_ms)
-    temp_ctrl_titles.append(f'VMM {i} Temperature')
-temp_tab.add_dropdown_menu(title='# data points shown', option_names=['10', '50', '100', '1000', '10000'], option_values=[10, 50, 100, 1000, 10000], ctrl_var=temp_ctrl_titles, on_change_callback=temp_tab.change_buffer_size_multiple)
+vmm_plot_ids = []
+for i in range(num_vmms):
+    plot_id = f'vmm_temp_{i}'
+    temp_tab.add_plot(plot_id=plot_id, title=f'VMM {i} Temperature', channels=[plot_id],
+                       x_axis=('Time since present', 's'), y_axis=('Temperature', 'degC'),
+                       offsets=[vmm_temperatures_offset], buffer_size=10)
+    temp_tab.start_timer(plot_id=plot_id, interval_ms=interval_time_ms)
+    vmm_plot_ids.append(plot_id)
+temp_tab.add_dropdown_menu(title='# data points shown', option_names=['10', '50', '100', '1000', '10000'], option_values=[10, 50, 100, 1000, 10000], ctrl_var=vmm_plot_ids, on_change_callback=temp_tab.change_buffer_size_multiple)
 
 plotter.run()

--- a/launch_GUI.py
+++ b/launch_GUI.py
@@ -1,4 +1,5 @@
 from core_tools.gui.live_plotter_GUI_class import LivePlotter
+from core_tools.gui.models import AggregateTile
 from core_tools.MKSPDR2000_pressure.save_pressure_readings_functions import create_pressure_log_csv
 from core_tools.VaisalaDMT143_H2Osensor.save_H2O_sensor_readings_functions import create_H2O_log_csv
 from core_tools.alarms import AlarmSpec
@@ -129,5 +130,12 @@ for i in range(num_vmms):
     temp_tab.start_timer(plot_id=plot_id, interval_ms=interval_time_ms)
     vmm_plot_ids.append(plot_id)
 temp_tab.add_dropdown_menu(title='# data points shown', option_names=['10', '50', '100', '1000', '10000'], option_values=[10, 50, 100, 1000, 10000], ctrl_var=vmm_plot_ids, on_change_callback=temp_tab.change_buffer_size_multiple)
+
+'''STATUS STRIP -- always visible above the tabs, regardless of which one is selected'''
+plotter.set_status_strip([
+    'ov_pressure_g1', 'ov_pressure_g2', 'gauge_pressure',
+    'filter_line_flow', 'filter_line_pressure', 'filter_line_h2o',
+    AggregateTile(label='VMM max', channels=vmm_plot_ids, reduce='max', jump_to_tab='VMM Temperatures'),
+])
 
 plotter.run()

--- a/launch_GUI.py
+++ b/launch_GUI.py
@@ -5,7 +5,6 @@ from core_tools.alarms import AlarmSpec
 
 '''Launches run control GUI for the 40L system as specified by the user in this file.'''
 #Create the files for logging data BEFORE registering the relevant channel because the plotter will look for the file when the channel is registered. Use the create_X_log_csv functions to create the files.
-#Do NOT use any filenames with whitespaces in them, as this will cause issues with the terminal command buttons.
 #The widgets (plots, buttons, etc.) are added to the GUI window in the order they are written here and fill from left to right, top to bottom.
 #For more infromation on how to use the LivePlotter class, see source code at core_tools/gui/live_plotter_GUI_class.py
 
@@ -107,15 +106,15 @@ pressure_tab.start_timer(plot_id='filter_line_h2o', interval_ms=interval_time_ms
 #pressure tab controls
 pressure_ctrl_plot_ids = ['ov_pressure', 'gauge_pressure', 'filter_line_flow', 'filter_line_pressure', 'filter_line_temperature', 'filter_line_h2o']
 
-pressure_tab.add_dropdown_menu(title='Pressure log increment', option_names=['2s', '10s', '1m', '10m', '1hr'], option_values=[2, 10, 60, 600, 3600], ctrl_var='Log Outer Vessel Pressure', on_change_callback=pressure_tab.change_cmd)
-pressure_tab.add_dropdown_menu(title='H2O concentration log increment', option_names=['2s', '10s', '1m', '10m', '1hr'], option_values=[2, 10, 60, 600, 3600], ctrl_var='Log H2O Concentration', on_change_callback=pressure_tab.change_cmd)
-
-pressure_tab.add_command_button(title='Log Outer Vessel Pressure', command=f'python log_pressure.py {outer_vessel_pressure_log_filepath} COM3 2')
-pressure_tab.add_command_button(title='Log H2O Concentration', command=f'python log_H2O_readings.py {vaisala_H2O_log_filepath} COM7 2')
+log_interval_options = [('2s', 2), ('10s', 10), ('1m', 60), ('10m', 600), ('1hr', 3600)]
+pressure_tab.add_logger_control(id='log_ov_pressure', label='OV Pressure', script='log_pressure.py',
+                                 log_filepath=outer_vessel_pressure_log_filepath, port='COM3',
+                                 interval_options=log_interval_options, default_interval=2)
+pressure_tab.add_logger_control(id='log_h2o', label='H2O Concentration', script='log_H2O_readings.py',
+                                 log_filepath=vaisala_H2O_log_filepath, port='COM7',
+                                 interval_options=log_interval_options, default_interval=2)
 
 pressure_tab.add_dropdown_menu(title='# data points shown', option_names=['10', '50', '100', '1000', '10000', '100000'], option_values=[10, 50, 100, 1000, 10000, 100000], ctrl_var=pressure_ctrl_plot_ids, on_change_callback=pressure_tab.change_buffer_size_multiple)
-
-pressure_tab.cmd_timer(100)
 
 '''VMM TEMPERATURES TAB'''
 temp_tab = plotter.create_tab(tab_name='VMM Temperatures', plots_per_row=4)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest

--- a/tests/test_alarms.py
+++ b/tests/test_alarms.py
@@ -1,0 +1,252 @@
+'''Unit tests for core_tools/alarms.py -- pure Python, no Qt, no display required.
+Run with: pytest tests/test_alarms.py -v'''
+
+import math
+
+import pandas as pd
+import pytest
+
+from core_tools.alarms import AlarmEvaluator, AlarmSpec, AlarmState, DisplayStatus, display_status
+from core_tools.gui.get_data_for_GUI import get_outer_vessel_gauge_pressure
+
+
+def feed(evaluator, channel_id, spec, values, start_t=0.0, dt=1.0, log_interval_s=1.0):
+    '''Feed `values` as consecutive samples 1 tick apart (each its own evaluate_channel
+    call, matching how a real scan only sees new rows since the previous scan), and
+    return the state after the last one.'''
+    t = start_t
+    for value in values:
+        evaluator.evaluate_channel(channel_id, spec, [(t, value)], now=t, log_interval_s=log_interval_s)
+        t += dt
+    return evaluator.state_for(channel_id)
+
+
+# --- boundary: must be strictly greater to trip ---
+
+def test_boundary_below_limit_never_trips():
+    spec = AlarmSpec(high=40.0, clear_high=38.0)
+    evaluator = AlarmEvaluator()
+    state = feed(evaluator, 'vmm', spec, [39.9, 39.9, 39.9])
+    assert state.state == AlarmState.OK
+
+
+def test_boundary_exactly_at_limit_does_not_trip():
+    spec = AlarmSpec(high=40.0, clear_high=38.0)
+    evaluator = AlarmEvaluator()
+    state = feed(evaluator, 'vmm', spec, [40.0, 40.0, 40.0])
+    assert state.state == AlarmState.OK, "exactly at the limit must not trip -- comparison is strictly greater"
+
+
+def test_boundary_just_above_limit_trips():
+    spec = AlarmSpec(high=40.0, clear_high=38.0)
+    evaluator = AlarmEvaluator()
+    state = feed(evaluator, 'vmm', spec, [40.1, 40.1, 40.1])
+    assert state.state == AlarmState.ALARM
+
+
+# --- debounce ---
+
+def test_debounce_two_consecutive_breaches_does_not_trip():
+    spec = AlarmSpec(high=40.0, clear_high=38.0, consecutive_samples=3)
+    evaluator = AlarmEvaluator()
+    state = feed(evaluator, 'vmm', spec, [41.0, 41.0])
+    assert state.state == AlarmState.OK
+
+
+def test_debounce_three_consecutive_breaches_trips():
+    spec = AlarmSpec(high=40.0, clear_high=38.0, consecutive_samples=3)
+    evaluator = AlarmEvaluator()
+    state = feed(evaluator, 'vmm', spec, [41.0, 41.0, 41.0])
+    assert state.state == AlarmState.ALARM
+
+
+def test_debounce_resets_on_in_range_sample():
+    spec = AlarmSpec(high=40.0, clear_high=38.0, consecutive_samples=3)
+    evaluator = AlarmEvaluator()
+    state = feed(evaluator, 'vmm', spec, [41.0, 41.0, 39.0, 41.0, 41.0])
+    assert state.state == AlarmState.OK, "an in-range sample must reset the debounce counter"
+
+
+# --- deadband ---
+
+def test_deadband_does_not_clear_inside_the_band():
+    spec = AlarmSpec(high=40.0, clear_high=38.0, consecutive_samples=3)
+    evaluator = AlarmEvaluator()
+    state = feed(evaluator, 'vmm', spec, [41.0, 41.0, 41.0])
+    assert state.state == AlarmState.ALARM
+    evaluator.evaluate_channel('vmm', spec, [(10.0, 39.0)], now=10.0, log_interval_s=1.0)
+    assert evaluator.state_for('vmm').state == AlarmState.ALARM, "39 is inside the deadband (limit=40, clear=38) -- must stay ALARM"
+
+
+def test_deadband_clears_at_the_clear_threshold():
+    spec = AlarmSpec(high=40.0, clear_high=38.0, consecutive_samples=3)
+    evaluator = AlarmEvaluator()
+    feed(evaluator, 'vmm', spec, [41.0, 41.0, 41.0])
+    evaluator.evaluate_channel('vmm', spec, [(10.0, 38.0)], now=10.0, log_interval_s=1.0)
+    assert evaluator.state_for('vmm').state == AlarmState.OK
+
+
+# --- gauge pressure |p| > 5.0 (strictly greater), independent of sign ---
+
+def test_gauge_pressure_exactly_five_does_not_trip():
+    spec = AlarmSpec(abs_high=5.0, clear_abs_high=4.5)
+    evaluator = AlarmEvaluator()
+    state = feed(evaluator, 'gauge', spec, [5.0, 5.0, 5.0])
+    assert state.state == AlarmState.OK, "a saturated +-5V sensor reads exactly 5.00 and must not trip"
+
+
+def test_gauge_pressure_above_five_trips():
+    spec = AlarmSpec(abs_high=5.0, clear_abs_high=4.5)
+    evaluator = AlarmEvaluator()
+    state = feed(evaluator, 'gauge', spec, [5.01, 5.01, 5.01])
+    assert state.state == AlarmState.ALARM
+
+
+def test_gauge_pressure_negative_above_five_trips():
+    spec = AlarmSpec(abs_high=5.0, clear_abs_high=4.5)
+    evaluator = AlarmEvaluator()
+    state = feed(evaluator, 'gauge', spec, [-5.01, -5.01, -5.01])
+    assert state.state == AlarmState.ALARM
+
+
+# --- outer vessel: real Pascal->Torr conversion, and Units=Off -> NO_DATA ---
+
+def test_outer_vessel_pascal_conversion_trips_alarm():
+    # 760 Torr / 0.0075006168 Torr-per-Pascal ~= 101324 Pa; use a comfortably higher value.
+    df = pd.DataFrame({'Gauge 1': [110000.0, 110000.0, 110000.0], 'Units': ['Pascal', 'Pascal', 'Pascal']})
+    pressures = get_outer_vessel_gauge_pressure(df, 1)
+    assert all(p > 760.0 for p in pressures), "sanity check on the conversion itself"
+
+    spec = AlarmSpec(high=760.0, clear_high=750.0)
+    evaluator = AlarmEvaluator()
+    state = feed(evaluator, 'ov_g1', spec, list(pressures))
+    assert state.state == AlarmState.ALARM
+
+
+def test_outer_vessel_units_off_yields_no_data_not_ok():
+    df = pd.DataFrame({'Gauge 1': [13.93], 'Units': ['Off']})
+    pressures = get_outer_vessel_gauge_pressure(df, 1)
+    assert math.isnan(pressures.iloc[0])
+
+    spec = AlarmSpec(high=760.0, clear_high=750.0)
+    evaluator = AlarmEvaluator()
+    state = feed(evaluator, 'ov_g1', spec, list(pressures))
+    assert state.state == AlarmState.NO_DATA
+
+
+# --- NaN never satisfies an OK comparison ---
+
+def test_nan_is_no_data_not_ok_even_with_no_limit_configured():
+    evaluator = AlarmEvaluator()
+    state = feed(evaluator, 'x', None, [float('nan')])
+    assert state.state == AlarmState.NO_DATA
+
+
+def test_nan_does_not_trip_and_does_not_read_as_ok():
+    spec = AlarmSpec(high=40.0, clear_high=38.0)
+    evaluator = AlarmEvaluator()
+    state = feed(evaluator, 'x', spec, [float('nan'), float('nan'), float('nan')])
+    assert state.state == AlarmState.NO_DATA
+    assert state.state != AlarmState.OK
+    assert state.state != AlarmState.ALARM
+
+
+# --- staleness ---
+
+def test_staleness_fires_at_five_times_interval_and_clears_on_fresh_sample():
+    spec = AlarmSpec(high=40.0, clear_high=38.0, stale_multiplier=5)
+    evaluator = AlarmEvaluator()
+    log_interval_s = 2.0
+
+    evaluator.evaluate_channel('vmm', spec, [(0.0, 30.0)], now=0.0, log_interval_s=log_interval_s)
+    assert evaluator.state_for('vmm').state == AlarmState.OK
+
+    # just under the threshold (5 * 2s = 10s) -- must not be stale yet
+    evaluator.evaluate_channel('vmm', spec, [], now=9.9, log_interval_s=log_interval_s)
+    assert evaluator.state_for('vmm').state == AlarmState.OK
+
+    # past the threshold
+    evaluator.evaluate_channel('vmm', spec, [], now=10.1, log_interval_s=log_interval_s)
+    assert evaluator.state_for('vmm').state == AlarmState.STALE
+
+    # a fresh sample clears it immediately, no debounce needed
+    evaluator.evaluate_channel('vmm', spec, [(10.2, 30.0)], now=10.2, log_interval_s=log_interval_s)
+    assert evaluator.state_for('vmm').state == AlarmState.OK
+
+
+def test_staleness_applies_even_without_an_alarm_spec():
+    evaluator = AlarmEvaluator()
+    evaluator.evaluate_channel('flow', None, [(0.0, 1.0)], now=0.0, log_interval_s=1.0)
+    evaluator.evaluate_channel('flow', None, [], now=100.0, log_interval_s=1.0)
+    assert evaluator.state_for('flow').state == AlarmState.STALE
+
+
+# --- latching + acknowledge ---
+
+def test_latching_full_lifecycle():
+    spec = AlarmSpec(high=40.0, clear_high=38.0, consecutive_samples=3)
+    evaluator = AlarmEvaluator()
+
+    feed(evaluator, 'vmm', spec, [41.0, 41.0, 41.0])
+    state = evaluator.state_for('vmm')
+    assert state.state == AlarmState.ALARM
+    assert display_status(state) == DisplayStatus.ALARM
+
+    # value returns in range -> "cleared, unacknowledged", not silently OK
+    evaluator.evaluate_channel('vmm', spec, [(10.0, 30.0)], now=10.0, log_interval_s=1.0)
+    state = evaluator.state_for('vmm')
+    assert state.state == AlarmState.OK
+    assert state.latched is True
+    assert state.acknowledged is False
+    assert display_status(state) == DisplayStatus.CLEARED
+
+    # Acknowledge -> fully OK
+    evaluator.acknowledge('vmm', now=11.0)
+    state = evaluator.state_for('vmm')
+    assert state.latched is False
+    assert display_status(state) == DisplayStatus.OK
+
+    # re-trigger after clearing raises the banner again (fresh debounce required)
+    evaluator.evaluate_channel('vmm', spec, [(12.0, 41.0), (13.0, 41.0)], now=13.0, log_interval_s=1.0)
+    assert evaluator.state_for('vmm').state == AlarmState.OK, "only 2 fresh breaching samples -- must not trip yet"
+    evaluator.evaluate_channel('vmm', spec, [(14.0, 41.0)], now=14.0, log_interval_s=1.0)
+    state = evaluator.state_for('vmm')
+    assert state.state == AlarmState.ALARM
+    assert state.acknowledged is False
+    assert display_status(state) == DisplayStatus.ALARM
+
+
+def test_acknowledge_while_still_active_dismisses_banner_but_stays_alarm():
+    spec = AlarmSpec(high=40.0, clear_high=38.0, consecutive_samples=3)
+    evaluator = AlarmEvaluator()
+    feed(evaluator, 'vmm', spec, [41.0, 41.0, 41.0])
+
+    evaluator.acknowledge('vmm', now=10.0)
+    state = evaluator.state_for('vmm')
+    assert state.state == AlarmState.ALARM, "acknowledging a still-active alarm must not change the live condition"
+    assert state.acknowledged is True
+
+    # it clears afterward -- this re-raises the banner even though it was acked while active
+    evaluator.evaluate_channel('vmm', spec, [(11.0, 30.0)], now=11.0, log_interval_s=1.0)
+    state = evaluator.state_for('vmm')
+    assert state.state == AlarmState.OK
+    assert state.latched is True
+    assert state.acknowledged is False
+    assert display_status(state) == DisplayStatus.CLEARED
+
+
+# --- alarms evaluate independently of plot pause state ---
+
+def test_evaluator_has_no_concept_of_pause_and_keeps_evaluating():
+    # The evaluator's API takes no "paused" argument anywhere -- pausing a plot is a
+    # GUI-only concern (whether curve.setData() gets called), so there is nothing a
+    # paused plot could do to suppress this. Demonstrated by evaluating normally with
+    # no plot/GUI object involved at all.
+    spec = AlarmSpec(high=40.0, clear_high=38.0, consecutive_samples=3)
+    evaluator = AlarmEvaluator()
+    state = feed(evaluator, 'vmm', spec, [41.0, 41.0, 41.0])
+    assert state.state == AlarmState.ALARM
+
+
+if __name__ == '__main__':
+    raise SystemExit(pytest.main([__file__, '-v']))

--- a/tests/test_decimate.py
+++ b/tests/test_decimate.py
@@ -1,0 +1,55 @@
+import numpy as np
+import pytest
+
+from core_tools.gui.decimate import decimate_min_max
+
+
+def test_below_cap_returns_unchanged():
+    x = np.arange(100)
+    y = np.sin(x)
+    out_x, out_y = decimate_min_max(x, y, max_points=20000)
+    assert list(out_x) == list(x)
+    assert list(out_y) == list(y)
+
+
+def test_decimates_above_cap():
+    x = np.arange(50000)
+    y = np.zeros(50000)
+    out_x, out_y = decimate_min_max(x, y, max_points=20000)
+    assert len(out_x) <= 20000
+    assert len(out_x) == len(out_y)
+
+
+def test_output_is_time_ordered():
+    x = np.arange(50000)
+    y = np.sin(x / 100.0)
+    out_x, out_y = decimate_min_max(x, y, max_points=20000)
+    assert list(out_x) == sorted(out_x)
+
+
+def test_spike_is_never_hidden_unlike_naive_stride():
+    n = 100000
+    x = np.arange(n)
+    y = np.zeros(n)
+    spike_index = 12345
+    y[spike_index] = 1000.0  # a single-sample spike, easy for a naive stride to skip
+
+    max_points = 2000
+    stride = n // max_points
+    strided_y = y[::stride]
+    assert 1000.0 not in strided_y, "sanity check: naive stride does drop this spike"
+
+    out_x, out_y = decimate_min_max(x, y, max_points=max_points)
+    assert 1000.0 in out_y, "min/max decimation must preserve the spike naive striding would drop"
+
+
+def test_handles_nan_values_without_crashing():
+    x = np.arange(50000)
+    y = np.full(50000, np.nan)
+    y[100] = 5.0
+    out_x, out_y = decimate_min_max(x, y, max_points=20000)
+    assert len(out_x) <= 20000
+
+
+if __name__ == '__main__':
+    raise SystemExit(pytest.main([__file__, '-v']))

--- a/tests/test_get_data_for_gui.py
+++ b/tests/test_get_data_for_gui.py
@@ -1,0 +1,96 @@
+import io
+import os
+import time
+import datetime
+
+import pandas as pd
+import pytest
+
+from core_tools.gui.get_data_for_GUI import read_last_n_rows_filtered, get_seconds_ago
+
+
+def _write_vmm_file(path, n_timestamps, start_dt):
+    '''16-channel VMM-style file (fec 0-1, hyb 0-3, vmm 0-1) with n_timestamps full
+    sweeps, using \\r\\n line endings to also exercise that path.'''
+    with open(path, 'wb') as f:
+        f.write(b'timestamp,fec,hyb,vmm,temperature\r\n')
+        for t in range(n_timestamps):
+            ts = (start_dt + datetime.timedelta(seconds=2 * t)).strftime('%Y-%m-%d %H:%M:%S')
+            for fec in range(2):
+                for hyb in range(4):
+                    for vmm in range(2):
+                        channel = fec * 8 + hyb * 2 + vmm
+                        temp = 20.0 + channel + t * 0.001
+                        f.write(f"{ts},{fec},{hyb},{vmm},{temp}\r\n".encode())
+
+
+def test_filtered_read_matches_full_file_filter(tmp_path):
+    path = str(tmp_path / 'vmm.csv')
+    start = datetime.datetime.now() - datetime.timedelta(seconds=2 * 500)
+    _write_vmm_file(path, n_timestamps=500, start_dt=start)
+
+    full = pd.read_csv(path)
+    for vmm_num in (0, 5, 7, 15):
+        expected = full[full['fec'] * 8 + full['hyb'] * 2 + full['vmm'] == vmm_num].tail(20)
+        got = read_last_n_rows_filtered(path, n=20, vmm_num=vmm_num)
+        assert list(got['temperature']) == pytest.approx(list(expected['temperature']))
+        assert list(got['timestamp']) == list(expected['timestamp'])
+
+
+def test_filtered_read_respects_n_and_chronological_order(tmp_path):
+    path = str(tmp_path / 'vmm.csv')
+    start = datetime.datetime.now() - datetime.timedelta(seconds=2 * 2000)
+    _write_vmm_file(path, n_timestamps=2000, start_dt=start)
+
+    got = read_last_n_rows_filtered(path, n=50, vmm_num=3, chunk_size=8192)
+    assert len(got) == 50
+    timestamps = pd.to_datetime(got['timestamp'])
+    assert list(timestamps) == sorted(timestamps), "rows must come back in chronological order"
+
+
+def test_filtered_read_is_not_quadratic(tmp_path):
+    # A crude but meaningful guard: doubling the file size should not roughly
+    # quadruple the time (the O(n^2) bug would re-filter all accumulated bytes on
+    # every chunk, which scales badly as matches get sparser deeper into the file).
+    small_path = str(tmp_path / 'vmm_small.csv')
+    big_path = str(tmp_path / 'vmm_big.csv')
+    start = datetime.datetime.now() - datetime.timedelta(seconds=2 * 8000)
+    _write_vmm_file(small_path, n_timestamps=2000, start_dt=start)
+    _write_vmm_file(big_path, n_timestamps=8000, start_dt=start)
+
+    t0 = time.perf_counter()
+    read_last_n_rows_filtered(small_path, n=50, vmm_num=9, chunk_size=8192)
+    small_elapsed = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    read_last_n_rows_filtered(big_path, n=50, vmm_num=9, chunk_size=8192)
+    big_elapsed = time.perf_counter() - t0
+
+    print(f"small(2000 rows/ts)={small_elapsed:.4f}s big(8000 rows/ts, 4x)={big_elapsed:.4f}s")
+    # Linear scaling would be ~4x; a generous 10x ceiling still clearly rules out
+    # quadratic scaling (which would be ~16x) without being a flaky timing test.
+    assert big_elapsed < small_elapsed * 10 + 0.05
+
+
+def test_get_seconds_ago_correct_in_a_non_utc_timezone():
+    original_tz = os.environ.get('TZ')
+    try:
+        os.environ['TZ'] = 'Pacific/Honolulu'  # no DST, UTC-10 -- a real timezone the doc calls out
+        if hasattr(time, 'tzset'):
+            time.tzset()
+
+        now_local_naive = datetime.datetime.now()
+        df = pd.DataFrame({'Time': [now_local_naive.strftime('%Y-%m-%d %H:%M:%S')]})
+        seconds_ago = get_seconds_ago(df)
+        assert abs(seconds_ago.iloc[0]) < 5, f"a 'now' timestamp should read as ~0 seconds ago, got {seconds_ago.iloc[0]}"
+    finally:
+        if original_tz is None:
+            os.environ.pop('TZ', None)
+        else:
+            os.environ['TZ'] = original_tz
+        if hasattr(time, 'tzset'):
+            time.tzset()
+
+
+if __name__ == '__main__':
+    raise SystemExit(pytest.main([__file__, '-v']))


### PR DESCRIPTION
## Summary

Full implementation of `UI_REDESIGN_PROMPT.md`: restructures the layout (status strip, alarm banner, event log, Overview tab, rebuilt VMM tab, collapsible control dock and group boxes) and adds a complete alarm system, landed as 10 phased commits plus a follow-up group-box fix caught by screenshot review and a README update.

- Replaced ten parallel title-keyed dicts with `Channel`/`Plot` dataclasses and a channel registry (`plot_id` vs. renameable `title` split)
- Structured logger subprocess handling: real argv lists (no more shell-string splitting, no more "no spaces in filenames" restriction), live serial port dropdown, non-silent crash reporting with captured stderr
- `core_tools/alarms.py`: pure-Python alarm state machine (OK/ALARM/STALE/NO_DATA, debounce, deadband, latching + acknowledge), with a real pytest suite
- Per-plot value readouts, offset-corrected threshold lines, alarm-driven coloring — backed by one independent alarm-scanner timer so pausing a plot never pauses its channel's alarm evaluation
- Status strip, alarm banner (latching, Acknowledge/Acknowledge All, click-to-navigate), tab alarm-count badges
- Collapsible, filterable event log mirrored to a timestamped file on disk; fixed a real cross-thread Qt bug surfaced while wiring subprocess stderr into it
- New Overview tab (tiles + sparklines) and rebuilt VMM Temperatures tab (4×4 tile grid + one overlay plot, replacing 16 separate plots)
- Global time-window selector replacing per-tab point-count dropdowns, with min/max-per-bucket decimation (a naive stride would hide alarm-relevant spikes)
- Data layer: background-threaded scan with a per-tick shared file cache — verified exactly one disk read per file per tick even with 16 VMM channels sharing one file; fixed `read_last_n_rows_filtered`'s O(n²) bug, `get_seconds_ago`'s timezone handling, and the deprecated `app.exec_()`
- Gas System plots wrapped in collapsible `QGroupBox`es per their declared group (caught missing via an actual screenshot, not just behavioral tests)

## Test plan

- [x] `pytest tests/ -v` — 29 tests passing (alarm state machine, decimation, `read_last_n_rows_filtered`, timezone handling)
- [x] Headless smoke tests (`QT_QPA_PLATFORM=offscreen`) after every commit, including an 8-second run with real threaded scan cycles
- [x] Real crash-detection test against `log_pressure.py` with a bogus serial port (LED, error line, event log all confirmed)
- [x] Screenshots of the running app at 1440×900 and 1920×1080 (Overview, Gas System, VMM tabs), including a doctored VMM 7 alarm showing the banner/tile/border/threshold-line together
- [ ] Manual test against real hardware/serial ports (not possible in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)