### PR TITLE
Fix VMM tab layout squishing the plot, and Overview->VMM tile navigation

### DIFF
--- a/core_tools/gui/live_plotter_GUI_class.py
+++ b/core_tools/gui/live_plotter_GUI_class.py
@@ -279,11 +279,18 @@ class LivePlotter:
     # used by status-strip/overview tile clicks and the alarm banner's message.
     def jump_to_channel(self, channel_id):
         refs = self.channel_plots.get(channel_id, [])
-        if not refs:
+        if refs:
+            tab, plot_id = refs[0]
+            self.tabs.setCurrentWidget(tab)
+            tab.scroll_to_plot(plot_id)
             return
-        tab, plot_id = refs[0]
-        self.tabs.setCurrentWidget(tab)
-        tab.scroll_to_plot(plot_id)
+        # VMM channels have no LiveTab/Plot of their own -- VMMTab renders them as
+        # tiles + an overlay curve instead, so channel_plots never has an entry for
+        # them. Fall back to selecting whichever VMMTab actually owns this channel.
+        for tab in self.tab_objects.values():
+            if isinstance(tab, VMMTab) and channel_id in tab.channel_ids:
+                self.tabs.setCurrentWidget(tab)
+                return
 
     def jump_to_tab(self, tab_name):
         tab = self.tab_objects.get(tab_name)
@@ -1161,24 +1168,22 @@ class VMMTab(QtWidgets.QWidget):
         self._colors = {}  # channel_id -> assigned pen color, so alarm highlighting can revert to it
         self.paused = False
 
-        splitter = QtWidgets.QSplitter(QtCore.Qt.Horizontal)
+        # Overlay plot on top (gets the dominant share of the space -- it's the
+        # thing operators actually need to see) with the tile grid + Select
+        # All/None controls in a compact strip underneath, not squeezed beside it.
+        splitter = QtWidgets.QSplitter(QtCore.Qt.Vertical)
 
-        left_widget = QtWidgets.QWidget()
-        left_layout = QtWidgets.QVBoxLayout()
-        left_widget.setLayout(left_layout)
-        grid = QtWidgets.QGridLayout()
-        columns = 4
-        for i, channel_id in enumerate(self.channel_ids):
-            tile = self._build_tile(channel_id)
-            grid.addWidget(tile['frame'], i // columns, i % columns)
-            self.tiles[channel_id] = tile
-        left_layout.addLayout(grid)
-        left_layout.addStretch(1)
-        splitter.addWidget(left_widget)
+        self.overlay_widget = pg.PlotWidget(title='VMM Temperatures Overlay')
+        self.overlay_widget.setLabel('bottom', 'Time since present', units='s')
+        self.overlay_widget.setLabel('left', 'Temperature', units='degC')
+        self.overlay_widget.showGrid(x=True, y=True)
+        self.overlay_widget.addLegend()
+        splitter.addWidget(self.overlay_widget)
 
-        right_widget = QtWidgets.QWidget()
-        right_layout = QtWidgets.QVBoxLayout()
-        right_widget.setLayout(right_layout)
+        bottom_widget = QtWidgets.QWidget()
+        bottom_layout = QtWidgets.QVBoxLayout()
+        bottom_layout.setContentsMargins(4, 4, 4, 4)
+        bottom_widget.setLayout(bottom_layout)
 
         controls_row = QtWidgets.QHBoxLayout()
         select_all_button = QtWidgets.QPushButton('Select All')
@@ -1188,17 +1193,24 @@ class VMMTab(QtWidgets.QWidget):
         select_none_button.clicked.connect(self.select_none)
         controls_row.addWidget(select_none_button)
         controls_row.addStretch(1)
-        right_layout.addLayout(controls_row)
+        bottom_layout.addLayout(controls_row)
 
-        self.overlay_widget = pg.PlotWidget(title='VMM Temperatures Overlay')
-        self.overlay_widget.setLabel('bottom', 'Time since present', units='s')
-        self.overlay_widget.setLabel('left', 'Temperature', units='degC')
-        self.overlay_widget.showGrid(x=True, y=True)
-        self.overlay_widget.addLegend()
-        right_layout.addWidget(self.overlay_widget)
-        splitter.addWidget(right_widget)
-        splitter.setStretchFactor(0, 1)
-        splitter.setStretchFactor(1, 2)
+        grid = QtWidgets.QGridLayout()
+        grid.setSpacing(2)
+        columns = 4
+        for i, channel_id in enumerate(self.channel_ids):
+            tile = self._build_tile(channel_id)
+            grid.addWidget(tile['frame'], i // columns, i % columns)
+            self.tiles[channel_id] = tile
+        bottom_layout.addLayout(grid)
+
+        splitter.addWidget(bottom_widget)
+        splitter.setStretchFactor(0, 3)
+        splitter.setStretchFactor(1, 1)
+        # setStretchFactor only governs resize behavior, not the initial split (which
+        # QSplitter otherwise derives from sizeHint(), letting 16 tiles' natural width
+        # dominate and squeeze the plot down to a sliver) -- pin a sane initial split.
+        splitter.setSizes([600, 200])
 
         if threshold is None:
             for channel_id in self.channel_ids:
@@ -1227,19 +1239,24 @@ class VMMTab(QtWidgets.QWidget):
 
         frame = QtWidgets.QFrame()
         frame.setFrameShape(QtWidgets.QFrame.Box)
-        vbox = QtWidgets.QVBoxLayout()
-        frame.setLayout(vbox)
+        row = QtWidgets.QHBoxLayout()
+        row.setContentsMargins(4, 1, 4, 1)
+        row.setSpacing(4)
+        frame.setLayout(row)
 
-        top_row = QtWidgets.QHBoxLayout()
         checkbox = QtWidgets.QCheckBox()
         checkbox.setChecked(True)
         checkbox.stateChanged.connect(lambda state, cid=channel_id: self._on_checkbox_changed(cid, state))
-        top_row.addWidget(checkbox)
-        top_row.addWidget(QtWidgets.QLabel(f"VMM {channel.vmm_num} (F{fec}/H{hyb}/V{vmm})"))
-        vbox.addLayout(top_row)
+        row.addWidget(checkbox)
+
+        label = QtWidgets.QLabel(f"VMM {channel.vmm_num} (F{fec}/H{hyb}/V{vmm})")
+        label.setStyleSheet("font-size: 10px;")
+        row.addWidget(label)
 
         value_label = QtWidgets.QLabel('—')
-        vbox.addWidget(value_label)
+        value_label.setStyleSheet("font-size: 10px;")
+        row.addWidget(value_label)
+        row.addStretch(1)
 
         return {'frame': frame, 'checkbox': checkbox, 'value_label': value_label}
 


### PR DESCRIPTION
## Summary

Two bug fixes from live feedback after merging #1:

- **VMM Temperatures tab: plot was squished.** The tile grid and overlay plot were side-by-side in a horizontal `QSplitter`; `QSplitter`'s *initial* split comes from each pane's `sizeHint()`, not `setStretchFactor` (which only governs later resizes), so the 16 tiles' natural width dominated and shrank the plot to a sliver. Restructured to a vertical splitter — plot on top with the dominant, pinned initial share, a compact single-row tile strip underneath.
- **Overview tab: clicking a VMM tile did nothing.** `jump_to_channel()` only checked `channel_plots`, which is populated by `LiveTab.add_plot()` — VMM channels never go through that path since the VMM tab renders them as tiles + one overlay curve, not individual `Plot` objects. Added a fallback that finds the `VMMTab` owning the channel and selects it. Gas System tile navigation (which already worked) is unaffected.

## Test plan

- [x] `pytest tests/ -v` — 29 passing
- [x] Real headless screenshot of the rebuilt VMM tab confirming the plot is now clearly dominant and visible
- [x] `jump_to_channel('vmm_temp_7')` verified to switch to the VMM tab (previously a no-op)
- [x] Full `launch_GUI.py` smoke test (offscreen) — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)