### PR TITLE
Fix the real cause of the window exceeding fullscreen; restore plot proportions

### DIFF
--- a/core_tools/gui/live_plotter_GUI_class.py
+++ b/core_tools/gui/live_plotter_GUI_class.py
@@ -450,6 +450,7 @@ class LiveTab(QtWidgets.QWidget):
         header_row = QtWidgets.QHBoxLayout()
         for channel_id in plot.channel_ids:
             value_label = QtWidgets.QLabel(f"{self._channel(channel_id).label}: —")
+            value_label.setWordWrap(True)  # wrap instead of visually clipping when a multi-channel plot's combined text is wide
             header_row.addWidget(value_label)
             plot.value_labels.append(value_label)
         header_row.addStretch(1)
@@ -500,7 +501,7 @@ class LiveTab(QtWidgets.QWidget):
         # tab's flat grid if ungrouped) -- see _grid_for_group().
         container_widget = QtWidgets.QWidget()
         container_widget.setLayout(container)
-        container_widget.setMinimumSize(300, 220)
+        container_widget.setMinimumSize(320, 300)
         grid, index = self._grid_for_group(group)
         row, col = index // self.plots_per_row, index % self.plots_per_row
         grid.addWidget(container_widget, row, col)
@@ -865,6 +866,10 @@ class StatusStrip(QtWidgets.QWidget):
             heading = spec.label if isinstance(spec, AggregateTile) else self.plotter.channels[spec].label
             box.addWidget(QtWidgets.QLabel(heading))
             value_label = QtWidgets.QLabel('—')
+            # This tile sits directly in main_layout (no scroll area above it), so an
+            # unwrapped label's full-text-width minimumSizeHint would otherwise
+            # become a hard floor under the whole window -- see AlarmBanner.
+            value_label.setWordWrap(True)
             box.addWidget(value_label)
 
             frame.mousePressEvent = lambda event, s=spec: self._on_clicked(s)
@@ -935,6 +940,13 @@ class AlarmBanner(QtWidgets.QWidget):
 
         self.message_label = QtWidgets.QLabel('')
         self.message_label.setStyleSheet("font-weight: bold;")
+        # A QLabel without word wrap has a minimumSizeHint equal to its full
+        # (single-line) text width -- and Qt's layout-minimum-size constraint
+        # overrides "maximized" window state. Since this label sits directly in
+        # main_layout (not inside any scroll area) and its text length varies with
+        # whatever alarm is currently active, an unwrapped long message could force
+        # the whole window wider than any real screen the instant it appeared.
+        self.message_label.setWordWrap(True)
         self.message_label.mousePressEvent = self._on_message_clicked
         self.layout.addWidget(self.message_label, 1)
 
@@ -1148,6 +1160,7 @@ class OverviewTab(QtWidgets.QWidget):
 
         vbox.addWidget(QtWidgets.QLabel(channel.label))
         value_label = QtWidgets.QLabel('—')
+        value_label.setWordWrap(True)  # cheap insurance against the same unwrapped-label minimum-width issue as the banner/status strip
         vbox.addWidget(value_label)
 
         sparkline = pg.PlotWidget()
@@ -1289,6 +1302,7 @@ class VMMTab(QtWidgets.QWidget):
 
         value_label = QtWidgets.QLabel('—')
         value_label.setStyleSheet("font-size: 10px;")
+        value_label.setWordWrap(True)  # VMMTab has no scroll area, so an unwrapped label here would push the window wider -- see AlarmBanner
         row.addWidget(value_label)
         row.addStretch(1)
 


### PR DESCRIPTION
## Summary

Follow-up to #3, which didn't actually fix the reported "window bigger than fullscreen" bug (that fix only addressed launch-time sizing, but the real cause was dynamic), and fixes a regression #3 introduced (Gas System plots looked squished).

- **Found and fixed the real cause of the fullscreen bug.** `AlarmBanner.message_label` had no `setWordWrap(True)`. A `QLabel` without word wrap has a `minimumSizeHint()` equal to its full single-line text width, and Qt's layout-minimum-size constraint overrides "maximized" window state — a maximized window cannot shrink below its content's minimum size. The banner sits directly in `main_layout` (no scroll area above it), and its message length varies with whatever alarm is active, so a long message could force the whole window wider than any real screen the instant it appeared. This explains why it only happened "sometimes" and looked like dynamic growth rather than a launch-time bug. Verified directly: `main_window.minimumSizeHint().width()` was 1138px unwrapped vs 370px wrapped in the full app with a realistic long multi-alarm message. Applied the same fix to every other label carrying variable-length dynamic text outside a scroll area (status strip tiles, VMM tile values) or that was visibly clipping instead of expanding (per-plot header readouts, Overview tile values).
- **Restored plot proportions.** #3 also reduced each plot's minimum size to 300×220 while chasing the fullscreen bug, which is what made Gas System plots look squished/short. Restored to 320×300 — still more compact than the original 400×360, but no longer disproportionately short.

## Test plan

- [x] `pytest tests/ -v` — 29 passing
- [x] Direct before/after comparison of `minimumSizeHint()` with a long banner message (1138px → 370px)
- [x] Full-app test: window does not exceed the screen even with a realistic 5-alarm banner message forcing 3 lines of wrapped text
- [x] Screenshots at 1440×900 confirming both fixes together (proper plot proportions, wrapped banner, nothing cut off)
- [x] Full `launch_GUI.py` smoke test — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)