### PR TITLE
Move the event log into its own Event Terminal tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ Multi-channel plots get a real legend (colors are never encoded in the title). E
 
 - `plotter.build_overview_tab()` — call this **before** any other tab so it lands first. Dashboard of tiles (value + 5-minute sparkline) grouped by each channel's `overview_group`; no live plots. Build it after every `add_channel()` call it should reflect.
 - `plotter.create_tab(tab_name, plots_per_row)` — a regular tab; call `.add_plot(...)` on the result.
-- `plotter.build_vmm_tab(tab_name, channel_ids, threshold=None)` — the VMM Temperatures tab: a 4×4 tile grid (checkbox, current value, alarm color) beside one overlay plot of every checked channel's curve. `threshold=None` derives the single threshold line from the first channel's `AlarmSpec.high`.
+- `plotter.build_vmm_tab(tab_name, channel_ids, threshold=None)` — the VMM Temperatures tab: one overlay plot of every checked channel's curve, with a compact 4-column tile row (checkbox, current value, alarm color) underneath so the plot keeps the dominant share of the space. `threshold=None` derives the single threshold line from the first channel's `AlarmSpec.high`.
+- The Event Terminal tab is added automatically (by `plotter.run()`, after every tab above) — nothing to declare for it.
 
 ### Logger controls
 
@@ -104,11 +105,11 @@ A plain channel id becomes a tile showing its label/value/units. `AggregateTile`
 
 ### Time window and other global controls
 
-The control dock (right-hand pane) also carries: the global time-window selector (`1m`/`5m`/`15m`/`1h`/`6h`/`24h`, persisted via `QSettings`; each plot fetches `ceil(window_s / channel.log_interval_s)` rows, decimated to ~20000 points via min/max-per-bucket bucketing if that's exceeded so a spike is never hidden), Pause All / Resume All (curve redraws only — never affects alarm evaluation), and Acknowledge All.
+The control dock (right-hand pane) also carries: the global time-window selector (`1m`/`5m`/`15m`/`1h`/`6h`/`24h`, persisted via `QSettings`; each plot fetches `ceil(window_s / channel.log_interval_s)` rows, decimated to ~20000 points via min/max-per-bucket bucketing if that's exceeded so a spike is never hidden), and Pause All / Resume All (curve redraws only — never affects alarm evaluation). Acknowledging alarms is done from the alarm banner (Acknowledge / Acknowledge All).
 
-### Event log
+### Event Terminal
 
-Bottom pane, collapsible, filterable. Every alarm transition, logger start/stop/crash, captured subprocess stderr, and runtime threshold/interval change is logged there and mirrored to a timestamped `event_log_*.log` file in the working directory, so it survives a GUI crash the same way the data logs do.
+A tab of its own, added after every tab `launch_GUI.py` declares, filterable. Every alarm transition, logger start/stop/crash, captured subprocess stderr, and runtime threshold/interval change is logged there and mirrored to disk in `event_logs/`, one file per calendar date (`event_log_YYYY-MM-DD.log`) rather than one per launch, so relaunching the program the same day keeps appending to that day's file and it survives a GUI crash the same way the data logs do.
 
 ## Testing
 

--- a/core_tools/gui/live_plotter_GUI_class.py
+++ b/core_tools/gui/live_plotter_GUI_class.py
@@ -119,24 +119,13 @@ class LivePlotter:
         self.main_splitter.setStretchFactor(0, 4)
         self.main_splitter.setStretchFactor(1, 1)
 
-        top_widget = QtWidgets.QWidget()
-        top_layout = QtWidgets.QVBoxLayout()
-        top_layout.setContentsMargins(0, 0, 0, 0)
-        top_widget.setLayout(top_layout)
-        top_layout.addWidget(self.alarm_banner)
-        top_layout.addWidget(self.status_strip)
-        top_layout.addWidget(self.main_splitter)
-
-        # The control dock and the event log pane are the two collapsible regions
-        # (drag the splitter handle to 0 to collapse); the banner/strip/tabs above
-        # them are always visible instead, same as the doc's mockup.
-        self.outer_splitter = QtWidgets.QSplitter(QtCore.Qt.Vertical)
-        self.outer_splitter.setHandleWidth(SPLITTER_HANDLE_WIDTH)
-        self.outer_splitter.addWidget(top_widget)
-        self.outer_splitter.addWidget(self.event_log)
-        self.outer_splitter.setStretchFactor(0, 4)
-        self.outer_splitter.setStretchFactor(1, 1)
-        self.main_layout.addWidget(self.outer_splitter)
+        # The control dock is the one collapsible region left (drag the splitter
+        # handle to 0 to collapse); the event log used to sit in a second collapsible
+        # pane below this but now lives in its own "Event Terminal" tab instead (added
+        # in run(), so it lands after every tab launch_GUI.py creates).
+        self.main_layout.addWidget(self.alarm_banner)
+        self.main_layout.addWidget(self.status_strip)
+        self.main_layout.addWidget(self.main_splitter)
 
         self._restore_layout()
 
@@ -160,15 +149,11 @@ class LivePlotter:
         self.event_log.add_line(level, message)
 
     def _restore_layout(self):
-        outer_sizes = self.settings.value('outer_splitter_sizes')
-        if outer_sizes:
-            self.outer_splitter.setSizes([int(s) for s in outer_sizes])
         main_sizes = self.settings.value('main_splitter_sizes')
         if main_sizes:
             self.main_splitter.setSizes([int(s) for s in main_sizes])
 
     def _save_layout(self):
-        self.settings.setValue('outer_splitter_sizes', self.outer_splitter.sizes())
         self.settings.setValue('main_splitter_sizes', self.main_splitter.sizes())
 
     # Register a data source once so it can be referenced by id from any tab's plots,
@@ -362,6 +347,14 @@ class LivePlotter:
 
     # Show the window and start the event loop
     def run(self):
+        # The event log is a fixed system tab, not something launch_GUI.py declares,
+        # so it's added here (the last thing that happens before showing the window)
+        # rather than in __init__ -- that guarantees it lands after every tab
+        # launch_GUI.py created, without launch_GUI.py needing to know it exists.
+        self.tab_objects['Event Terminal'] = self.event_log
+        self.event_log.tab_name = 'Event Terminal'
+        self.tabs.addTab(self.event_log, 'Event Terminal')
+
         # Plain .show() sizes the window from the widget tree's natural sizeHint,
         # which for a QScrollArea with setWidgetResizable(True) is computed from its
         # *content* (e.g. every Gas System plot laid out without scrolling) rather
@@ -1016,13 +1009,14 @@ class AlarmBanner(QtWidgets.QWidget):
 
 
 class EventLog(QtWidgets.QWidget):
-    '''Read-only, filterable, collapsible log pane at the bottom of the window.
-    Every line is also mirrored to a file on disk (flushed on every write) so the
-    log survives a GUI crash, same as the data logs it sits next to. Log files live
-    in LOG_DIR, one per calendar date (not one per launch) so relaunching the
-    program the same day keeps appending to that day's file; if the program is still
-    running when the date changes, the next line written rolls over to a fresh file
-    for the new day.'''
+    '''Read-only, filterable log view, shown in its own "Event Terminal" tab (added
+    by LivePlotter.run() so it lands after every tab launch_GUI.py creates). Every
+    line is also mirrored to a file on disk (flushed on every write) so the log
+    survives a GUI crash, same as the data logs it sits next to. Log files live in
+    LOG_DIR, one per calendar date (not one per launch) so relaunching the program
+    the same day keeps appending to that day's file; if the program is still running
+    when the date changes, the next line written rolls over to a fresh file for the
+    new day.'''
 
     MAX_LINES = 5000
     LOG_DIR = 'event_logs'
@@ -1098,6 +1092,9 @@ class EventLog(QtWidgets.QWidget):
             self._file.close()
         except OSError:
             pass
+
+    def alarming_channel_ids(self, evaluator):
+        return set()  # the log isn't tied to specific channels, so it never gets its own badge
 
 
 class OverviewTab(QtWidgets.QWidget):


### PR DESCRIPTION
## Summary

Moves the event log out of a permanent bottom pane and into its own tab, per feedback that it was taking up too much space at all times.

- New **"Event Terminal"** tab, alongside Overview/Gas System/VMM Temperatures — every other tab (most noticeably Gas System) now gets the full window height instead of permanently sharing it with the log pane.
- The tab is added automatically by `LivePlotter.run()` (after every tab `launch_GUI.py` declares) — it's a fixed system tab, not something a scientist configures per experiment, so `launch_GUI.py` doesn't need to know it exists.
- Removed the now-single-pane `outer_splitter` (the control dock's splitter is the only collapsible region left) and added `EventLog.alarming_channel_ids()` so the tab-badge refresh loop keeps working now that the log is one of the tabs it iterates over.
- Updated the README's Event log section, plus the VMM tab section which was already stale from an earlier layout change this session (plot beside the tile grid → plot on top, compact tile row underneath).

## Test plan

- [x] `pytest tests/ -v` — 29 passing
- [x] Verified tab order: Overview, Gas System, VMM Temperatures, Event Terminal
- [x] Verified tab-badge refresh doesn't break with the log as a tab
- [x] Screenshots confirming Gas System now gets the full window height, and the new tab renders correctly
- [x] Full `launch_GUI.py` smoke test — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)