### PR TITLE
Bound stale-channel age label to fixed-width units

### DIFF
--- a/core_tools/gui/live_plotter_GUI_class.py
+++ b/core_tools/gui/live_plotter_GUI_class.py
@@ -62,7 +62,15 @@ def format_channel_value(channel, state, status, offset, now):
         return text, f"color: {ALARM_COLOR}; font-weight: bold;"
     if status == DisplayStatus.STALE:
         age = (now - state.last_timestamp) if state.last_timestamp else 0
-        return f"{text} (stale {age:.0f}s)", "color: grey;"
+        if age < 600:
+            age_str = f"{age:.0f}s"
+        elif age < 180 * 60:
+            age_str = f"{age / 60:.0f}m"
+        elif age < 72 * 3600:
+            age_str = f"{age / 3600:.0f}h"
+        else:
+            age_str = f"{age / 86400:.0f}d"
+        return f"{text} (stale {age_str})", "color: grey;"
     if status == DisplayStatus.CLEARED:
         return text, "color: #b8860b;"
     return text, ""


### PR DESCRIPTION
## Summary
- Widgets were visibly resizing every second even with no new data, because the stale-channel age suffix (`(stale Ns)`) grew an unbounded number of digits, changing the value label's size hint and rippling through the grid layout.
- The age display now steps through units — seconds under 600s, minutes under 180m, hours under 72h, then days — so the string stays short and only changes units infrequently instead of every second.

## Test plan
- [ ] Run the app, let a channel go stale, and confirm the tile/plot layout no longer jitters as the stale duration grows past each threshold (10min, 3hr, 3 days if feasible to simulate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)