### PR TITLE
Fix VMM status-strip jitter and scale tile grid for scrolling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 *.pyc
 *.pyo
 
+# pytest cache
+.pytest_cache/
+
 # Distribution
 dist/
 build/

--- a/core_tools/gui/live_plotter_GUI_class.py
+++ b/core_tools/gui/live_plotter_GUI_class.py
@@ -917,7 +917,7 @@ class StatusStrip(QtWidgets.QWidget):
 
         channel = self.plotter.channels[worst_channel_id]
         channel_index = channel.vmm_num if channel.vmm_num is not None else worst_channel_id
-        value_label.setText(f"{worst_value:.3g} {channel.units} (ch {channel_index})")
+        value_label.setText(f"{worst_value:.3g} {channel.units} (ch {channel_index:02d})")
         value_label.setStyleSheet(f"color: {ALARM_COLOR}; font-weight: bold;" if any_alarm else "")
 
 

--- a/core_tools/gui/live_plotter_GUI_class.py
+++ b/core_tools/gui/live_plotter_GUI_class.py
@@ -1254,7 +1254,14 @@ class VMMTab(QtWidgets.QWidget):
             self.tiles[channel_id] = tile
         bottom_layout.addLayout(grid)
 
-        splitter.addWidget(bottom_widget)
+        # Wrapped in a scroll area (rather than added to the splitter directly) so
+        # the tile grid can grow past 16 VMMs later -- extra rows scroll instead of
+        # squeezing the overlay plot or widening the window.
+        bottom_scroll = QtWidgets.QScrollArea()
+        bottom_scroll.setWidgetResizable(True)
+        bottom_scroll.setWidget(bottom_widget)
+
+        splitter.addWidget(bottom_scroll)
         splitter.setStretchFactor(0, 3)
         splitter.setStretchFactor(1, 1)
         # setStretchFactor only governs resize behavior, not the initial split (which
@@ -1296,6 +1303,7 @@ class VMMTab(QtWidgets.QWidget):
 
         checkbox = QtWidgets.QCheckBox()
         checkbox.setChecked(True)
+        checkbox.setStyleSheet("QCheckBox::indicator { width: 18px; height: 18px; }")
         checkbox.stateChanged.connect(lambda state, cid=channel_id: self._on_checkbox_changed(cid, state))
         row.addWidget(checkbox)
 
@@ -1305,7 +1313,7 @@ class VMMTab(QtWidgets.QWidget):
 
         value_label = QtWidgets.QLabel('—')
         value_label.setStyleSheet("font-size: 10px;")
-        value_label.setWordWrap(True)  # VMMTab has no scroll area, so an unwrapped label here would push the window wider -- see AlarmBanner
+        value_label.setWordWrap(True)  # keeps a stale/long reading from widening the tile grid inside the scroll area
         row.addWidget(value_label)
         row.addStretch(1)
 


### PR DESCRIPTION
## Summary
- The status strip's "VMM max" aggregate tile picked whichever VMM channel currently had the highest value and rendered its channel index unpadded (`ch 3` vs `ch 14`), so noisy readings near the alarm threshold flipped the digit count almost every scan tick — jittering the tile's size and, via word-wrap, the whole status strip's height. Most visible on the VMM tab since it (unlike other tabs) has no scroll area to absorb the fluctuation. Fixed by zero-padding the channel index.
- More VMMs are coming, so the 4x4 tile grid needs to grow past 16 without squeezing the overlay plot or widening the window. The tile grid + Select All/None controls now live in their own `QScrollArea` underneath the plot, and the toggle checkboxes are sized up slightly.
- Added `.pytest_cache/` to `.gitignore` (local pytest run artifact, not meant to be tracked).

## Test plan
- [ ] Watch the status strip while a VMM channel hovers near its alarm threshold and confirm the "VMM max" tile no longer jitters the strip's height.
- [ ] Open the VMM Temperatures tab, confirm the tile grid + Select All/None sit in a scrollable area under the plot, and the checkboxes read as slightly larger than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)